### PR TITLE
XDOC-28: Product name should appear in uppercase in the navigation panel

### DIFF
--- a/documentation-ui/src/main/resources/DocApp/Code/DocumentationNavigationPanel.xml
+++ b/documentation-ui/src/main/resources/DocApp/Code/DocumentationNavigationPanel.xml
@@ -183,7 +183,7 @@
   #getProduct($product)
   #getProductName($product $productName)
   #set ($discard = $xwiki.jsx.use('DocApp.Code.DocumentationNavigationPanel'))
-  #panelheader("$productName for ${stringtool.capitalize($target)}s")
+  #panelheader(" ${stringtool.capitalize($productName)} for ${stringtool.capitalize($target)}s")
   ## Escape special characters in macro parameter values.
   #set ($openToDoc = $doc.documentReference.toString().replaceAll('([~"])', '~$1'))
   ## TODO: Code below to be removed once https://jira.xwiki.org/browse/XWIKI-23621 is implemented and the parent POM


### PR DESCRIPTION
https://jira.xwiki.org/browse/XDOC-28

Applied uppercase to the panel header
