### PR TITLE
Confluence doc fixes

### DIFF
--- a/documentation-xwikiorg/documentation-xwikiorg-ui/src/main/resources/DocApp/Code/Confluence/ConfluenceMacroDocumentationClass.xml
+++ b/documentation-xwikiorg/documentation-xwikiorg-ui/src/main/resources/DocApp/Code/Confluence/ConfluenceMacroDocumentationClass.xml
@@ -255,7 +255,7 @@
       <classType>com.xpn.xwiki.objects.classes.StaticListClass</classType>
     </importSupportQualifier>
     <prettyName>
-      <customDisplay>{{include reference="AppWithinMinutes.Title"/}}</customDisplay>
+      <customDisplay>{{include reference="DocApp.Code.Confluence.ConfluenceTitleDisplayer"/}}</customDisplay>
       <disabled>0</disabled>
       <hint>The user-friendly macro name as it is presented in confluence (different from the confluence ID which is the technical name)</hint>
       <name>prettyName</name>

--- a/documentation-xwikiorg/documentation-xwikiorg-ui/src/main/resources/DocApp/Code/Confluence/ConfluenceMacroDocumentationClass.xml
+++ b/documentation-xwikiorg/documentation-xwikiorg-ui/src/main/resources/DocApp/Code/Confluence/ConfluenceMacroDocumentationClass.xml
@@ -96,7 +96,7 @@
       <name>correspondingXWikiFeature</name>
       <number>23</number>
       <picker>0</picker>
-      <prettyName>Corresponding feature in XWiki</prettyName>
+      <prettyName>Corresponding XWiki feature description</prettyName>
       <restricted>0</restricted>
       <rows>5</rows>
       <size>40</size>
@@ -113,14 +113,14 @@
       <disabled>0</disabled>
       <displayType>input</displayType>
       <freeText/>
-      <hint>The documentation of a feature that should be used in XWiki for this feature regardless of the import</hint>
+      <hint>The documentation of a feature that should be used in XWiki for this feature regardless of the import.</hint>
       <idField/>
       <largeStorage>0</largeStorage>
       <multiSelect>0</multiSelect>
       <name>equivXWikiFeaturePage</name>
       <number>20</number>
       <picker>1</picker>
-      <prettyName>Equivalent XWiki feature documentation page</prettyName>
+      <prettyName>Corresponding  XWiki feature documentation page</prettyName>
       <relationalStorage>0</relationalStorage>
       <separator> </separator>
       <separators/>
@@ -136,11 +136,11 @@
     <equivXWikiFeaturePageAnchor>
       <customDisplay/>
       <disabled>0</disabled>
-      <hint>The anchor in the documentation of a feature that should be used in XWiki for this feature regardless of the import</hint>
+      <hint>The anchor in the documentation of a feature that should be used in XWiki for this feature regardless of the import.</hint>
       <name>equivXWikiFeaturePageAnchor</name>
       <number>21</number>
       <picker>1</picker>
-      <prettyName>Equivalent XWiki feature documentation page anchor</prettyName>
+      <prettyName>Corresponding XWiki feature documentation page anchor</prettyName>
       <size>30</size>
       <unmodifiable>0</unmodifiable>
       <validationMessage/>
@@ -150,11 +150,11 @@
     <equivXWikiFeatureURL>
       <customDisplay/>
       <disabled>0</disabled>
-      <hint>The URL to the feature that should be used in XWiki for this feature regardless of the import</hint>
+      <hint>The URL to the feature that should be used in XWiki for this feature regardless of the import.</hint>
       <name>equivXWikiFeatureURL</name>
       <number>22</number>
       <picker>0</picker>
-      <prettyName>Equivalent XWiki feature documentation URL</prettyName>
+      <prettyName>Corresponding XWiki feature documentation URL</prettyName>
       <size>30</size>
       <unmodifiable>0</unmodifiable>
       <validationMessage/>
@@ -168,7 +168,7 @@
       <disabled>0</disabled>
       <displayType>select</displayType>
       <freeText/>
-      <hint/>
+      <hint>How well the corresponding feature in XWiki is equivalent to the Confluence feature. If the corresponding XWiki feature brings the same features with no important limitations, we consider  full equivalence. If corresponding features lack or have limitations, depending on the situation, we consider partial equivalence.</hint>
       <largeStorage>0</largeStorage>
       <multiSelect>0</multiSelect>
       <name>functionalEquivalenceQualifier</name>
@@ -193,7 +193,7 @@
       <disabled>0</disabled>
       <displayType>select</displayType>
       <freeText/>
-      <hint/>
+      <hint>There are different ways to import and handle Confluence macros in XWiki. This hints at how the macro looks like after a migration to XWiki.</hint>
       <largeStorage>0</largeStorage>
       <multiSelect>0</multiSelect>
       <name>handling</name>
@@ -236,7 +236,7 @@
       <disabled>0</disabled>
       <displayType>select</displayType>
       <freeText>allowed</freeText>
-      <hint>How well the macro is imported in XWiki</hint>
+      <hint>How well the Confluence macro is handled in XWiki. If all Confluence macro parameters are mapped to supported XWiki macro parameters, we consider this fully supported. If some parameters are not supported in XWiki, depending on the situation, we consider this partial.</hint>
       <largeStorage>0</largeStorage>
       <multiSelect>0</multiSelect>
       <name>importSupportQualifier</name>
@@ -270,11 +270,11 @@
     <requiredForImport>
       <customDisplay/>
       <disabled>0</disabled>
-      <hint>URL to an extension required for importing this macro</hint>
+      <hint>URL to an extension required for importing this macro.</hint>
       <name>requiredForImport</name>
       <number>14</number>
       <picker>0</picker>
-      <prettyName>Required for import URL</prettyName>
+      <prettyName>Required for import documentation URL</prettyName>
       <size>30</size>
       <unmodifiable>0</unmodifiable>
       <validationMessage/>
@@ -286,7 +286,7 @@
       <disabled>0</disabled>
       <hint>ID of an extension required for importing this macro</hint>
       <name>requiredForImportId</name>
-      <number>13</number>
+      <number>11</number>
       <picker>0</picker>
       <prettyName>Required for import extension ID</prettyName>
       <size>30</size>
@@ -303,12 +303,12 @@
       <disabled>0</disabled>
       <displayType>input</displayType>
       <freeText/>
-      <hint>Page of an extension required for importing this macro</hint>
+      <hint>Page of an extension required for importing this macro.</hint>
       <idField/>
       <largeStorage>0</largeStorage>
       <multiSelect>0</multiSelect>
       <name>requiredForImportPage</name>
-      <number>11</number>
+      <number>13</number>
       <picker>1</picker>
       <prettyName>Required for import documentation page</prettyName>
       <relationalStorage>0</relationalStorage>
@@ -326,9 +326,9 @@
     <requiredForImportPageAnchor>
       <customDisplay/>
       <disabled>0</disabled>
-      <hint>Anchor in the page of an extension required for importing this macro</hint>
+      <hint>Anchor in the page of an extension required for importing this macro.</hint>
       <name>requiredForImportPageAnchor</name>
-      <number>12</number>
+      <number>13</number>
       <picker>1</picker>
       <prettyName>Required for import documentation page anchor</prettyName>
       <size>30</size>
@@ -340,11 +340,11 @@
     <requiredForUsage>
       <customDisplay/>
       <disabled>0</disabled>
-      <hint>URL to the documentation of a extension required for using the imported macro</hint>
+      <hint>URL to the documentation of a extension required for using the imported macro.</hint>
       <name>requiredForUsage</name>
       <number>19</number>
       <picker>0</picker>
-      <prettyName>Required for usage URL</prettyName>
+      <prettyName>Required for usage documentation URL</prettyName>
       <size>30</size>
       <unmodifiable>0</unmodifiable>
       <validationMessage/>
@@ -387,7 +387,7 @@
       <disabled>0</disabled>
       <displayType>input</displayType>
       <freeText/>
-      <hint>Documentation page of an extension required for using this macro</hint>
+      <hint>Documentation page of an extension required for using this macro.</hint>
       <idField/>
       <largeStorage>0</largeStorage>
       <multiSelect>0</multiSelect>
@@ -410,7 +410,7 @@
     <requiredForUsagePageAnchor>
       <customDisplay/>
       <disabled>0</disabled>
-      <hint>Documentation page anchor of an extension required for using this macro</hint>
+      <hint>Documentation page anchor of an extension required for using this macro.</hint>
       <name>requiredForUsagePageAnchor</name>
       <number>18</number>
       <picker>1</picker>
@@ -443,7 +443,7 @@
       <disabled>0</disabled>
       <displayType>input</displayType>
       <freeText/>
-      <hint>The import target macro documentation, if applicable</hint>
+      <hint>The import target macro documentation, if applicable.</hint>
       <idField/>
       <largeStorage>0</largeStorage>
       <multiSelect>0</multiSelect>
@@ -466,7 +466,7 @@
     <xwikiPageAnchor>
       <customDisplay/>
       <disabled>0</disabled>
-      <hint>The anchor in the import target macro documentation, if applicable</hint>
+      <hint>The anchor in the import target macro documentation, if applicable.</hint>
       <name>xwikiPageAnchor</name>
       <number>9</number>
       <picker>1</picker>
@@ -480,7 +480,7 @@
     <xwikiURL>
       <customDisplay/>
       <disabled>0</disabled>
-      <hint>The import target macro documentation, if applicable</hint>
+      <hint>The import target macro documentation, if applicable.</hint>
       <name>xwikiURL</name>
       <number>10</number>
       <picker>0</picker>

--- a/documentation-xwikiorg/documentation-xwikiorg-ui/src/main/resources/DocApp/Code/Confluence/ConfluenceMacroDocumentationClassSheet.xml
+++ b/documentation-xwikiorg/documentation-xwikiorg-ui/src/main/resources/DocApp/Code/Confluence/ConfluenceMacroDocumentationClassSheet.xml
@@ -55,7 +55,45 @@
     #end
   #end
   ##
+  #macro (renderLinkEdit $class $urlPropertyName $pagePropertyName $pageAnchorPropertyName)
+    #set ($macro.pageProperty = $class.get($pagePropertyName))
+    #set ($macro.pageAnchorProperty = $class.get($pageAnchorPropertyName))
+    #set ($macro.urlProperty = $class.get($urlPropertyName))
+    &lt;fieldset class="confluenceMacroDocUrl"&gt;
+      &lt;legend&gt;$macro.pageProperty.prettyName.replace(' page', '')&lt;/legend&gt;
+      &lt;dl class="confluenceMacroDocPage"&gt;
+        &lt;dt class="confluenceMacroDocPageRef"&gt;
+          &lt;label for="${class.name}_0_${macro.pageProperty.name}"&gt;$macro.pageProperty.prettyName&lt;/label&gt;
+          &lt;span class="xHint"&gt;$!macro.pageProperty.hint&lt;/span&gt;
+          &lt;span class="xHint"&gt;Replace the URL in case of the target page is into the same wiki.&lt;/span&gt;
+        &lt;/dt&gt;
+        &lt;dd class="confluenceMacroDocPageRef"&gt;
+          {{/html}}$doc.display($pagePropertyName){{html clean="false"}}
+        &lt;/dd&gt;
+        &lt;dt class="confluenceMacroDocPageAnchor"&gt;
+          &lt;label for="${class.name}_0_${macro.pageAnchorProperty.name}"&gt;$macro.pageAnchorProperty.prettyName&lt;/label&gt;
+          &lt;span class="xHint"&gt;$!macro.pageAnchorProperty.hint&lt;/span&gt;
+          &lt;span class="xHint"&gt;Should be in addition to the page reference to have the section of the page.&lt;/span&gt;
+        &lt;/dt&gt;
+        &lt;dd class="confluenceMacroDocPageAnchor"&gt;
+          {{/html}}$doc.display($pageAnchorPropertyName){{html clean="false"}}
+        &lt;/dd&gt;
+      &lt;/dl&gt;
+      &lt;dl&gt;
+        &lt;dt&gt;
+          &lt;label for="${class.name}_0_${macro.urlProperty.name}"&gt;$macro.urlProperty.prettyName&lt;/label&gt;
+          &lt;span class="xHint"&gt;$!macro.urlProperty.hint&lt;/span&gt;
+          &lt;span class="xHint"&gt;This is mutually exclusive with the target XWiki page and target XWiki page anchor.&lt;/span&gt;
+        &lt;/dt&gt;
+        &lt;dd&gt;
+          {{/html}}$doc.display($urlPropertyName){{html clean="false"}}
+        &lt;/dd&gt;
+      &lt;/dl&gt;
+    &lt;/fieldset&gt;
+  #end
+  ##
   #set ($className = 'DocApp.Code.Confluence.ConfluenceMacroDocumentationClass')
+  #set ($discard = $xwiki.ssx.use('DocApp.Code.Confluence.ConfluenceMacroDocumentationClassSheet'))
   #set ($macroObj = $doc.getObject($className))
   #set ($confluenceId = $macroObj.confluenceId)
   #if ("$!confluenceId" != '')
@@ -74,16 +112,43 @@
   #if ($macroObj != $NULL)
     #set($class = $macroObj.xWikiClass)
     #if ($xcontext.action == 'edit')
-      (% class="xform" %)
-      (((
-        #foreach($property in $class.properties)
-          ; {{html clean="false"}}
-              &lt;label for="${className}_0_${property.name}"&gt;$property.prettyName&lt;/label&gt;
-              &lt;span class="xHint"&gt;$!property.hint&lt;/span&gt;
-            {{/html}}
-          : $doc.display($property.name)
-        #end
-      )))
+      {{html clean="false"}}
+        &lt;div class="xform confluenceMacroDocEdit" &gt;
+          #set ($linkPropertiesMap = {
+            'xwikiURL': ['xwikiPage', 'xwikiPageAnchor'],
+            'requiredForImport': ['requiredForImportPage', 'requiredForImportPageAnchor'],
+            'requiredForUsage': ['requiredForUsagePage', 'requiredForUsagePageAnchor'],
+            'equivXWikiFeatureURL': ['equivXWikiFeaturePage', 'equivXWikiFeaturePageAnchor']
+          })
+          #set ($propertiesForLink = [])
+          #set ($discard = $propertiesForLink.addAll($linkPropertiesMap.keySet()))
+          #foreach ($v in $linkPropertiesMap.values())
+            #set ($discard = $propertiesForLink.addAll($v))
+          #end
+          #foreach($property in $class.properties)
+            #if ($propertiesForLink.contains($property.name))
+              #if ($linkPropertiesMap.containsKey($property.name))
+                #set ($linkPropertyValue = $linkPropertiesMap[$property.name])
+                #renderLinkEdit($class $property.name, $linkPropertyValue[0], $linkPropertyValue[1])
+              #end
+            #else
+              #if ($foreach.first || $propertiesForLink.contains($class.properties[$foreach.count - 2].name))
+                &lt;dl&gt;
+              #end
+              &lt;dt&gt;
+                &lt;label for="${className}_0_${property.name}"&gt;$property.prettyName&lt;/label&gt;
+                &lt;span class="xHint"&gt;$!property.hint&lt;/span&gt;
+              &lt;/dt&gt;
+              &lt;dd&gt;
+                {{/html}}$doc.display($property.name){{html clean="false"}}
+              &lt;/dd&gt;
+              #if ($foreach.last || $propertiesForLink.contains($class.properties[$foreach.count].name))
+                &lt;/dl&gt;
+              #end
+            #end
+          #end
+        &lt;/div&gt;
+      {{/html}}
     #else
       #set ($importSupportQualifier = $macroObj.getValue('importSupportQualifier'))
       #if ($importSupportQualifier == 'partial')
@@ -223,4 +288,158 @@
     #end
   #end
 {{/velocity}}</content>
+  <object>
+    <name>DocApp.Code.Confluence.ConfluenceMacroDocumentationClassSheet</name>
+    <number>0</number>
+    <className>XWiki.StyleSheetExtension</className>
+    <guid>e407e276-3ecc-40aa-858b-d95288828855</guid>
+    <class>
+      <name>XWiki.StyleSheetExtension</name>
+      <customClass/>
+      <customMapping/>
+      <defaultViewSheet/>
+      <defaultEditSheet/>
+      <defaultWeb/>
+      <nameField/>
+      <validationScript/>
+      <cache>
+        <cache>0</cache>
+        <defaultValue>long</defaultValue>
+        <disabled>0</disabled>
+        <displayType>select</displayType>
+        <freeText>forbidden</freeText>
+        <largeStorage>0</largeStorage>
+        <multiSelect>0</multiSelect>
+        <name>cache</name>
+        <number>5</number>
+        <prettyName>Caching policy</prettyName>
+        <relationalStorage>0</relationalStorage>
+        <separator> </separator>
+        <separators>|, </separators>
+        <size>1</size>
+        <unmodifiable>0</unmodifiable>
+        <values>long|short|default|forbid</values>
+        <classType>com.xpn.xwiki.objects.classes.StaticListClass</classType>
+      </cache>
+      <code>
+        <contenttype>PureText</contenttype>
+        <disabled>0</disabled>
+        <editor>PureText</editor>
+        <name>code</name>
+        <number>2</number>
+        <prettyName>Code</prettyName>
+        <restricted>0</restricted>
+        <rows>20</rows>
+        <size>50</size>
+        <unmodifiable>0</unmodifiable>
+        <classType>com.xpn.xwiki.objects.classes.TextAreaClass</classType>
+      </code>
+      <contentType>
+        <cache>0</cache>
+        <disabled>0</disabled>
+        <displayType>select</displayType>
+        <freeText>forbidden</freeText>
+        <largeStorage>0</largeStorage>
+        <multiSelect>0</multiSelect>
+        <name>contentType</name>
+        <number>6</number>
+        <prettyName>Content Type</prettyName>
+        <relationalStorage>0</relationalStorage>
+        <separator> </separator>
+        <separators>|, </separators>
+        <size>1</size>
+        <unmodifiable>0</unmodifiable>
+        <values>CSS|LESS</values>
+        <classType>com.xpn.xwiki.objects.classes.StaticListClass</classType>
+      </contentType>
+      <name>
+        <disabled>0</disabled>
+        <name>name</name>
+        <number>1</number>
+        <prettyName>Name</prettyName>
+        <size>30</size>
+        <unmodifiable>0</unmodifiable>
+        <classType>com.xpn.xwiki.objects.classes.StringClass</classType>
+      </name>
+      <parse>
+        <disabled>0</disabled>
+        <displayFormType>select</displayFormType>
+        <displayType>yesno</displayType>
+        <name>parse</name>
+        <number>4</number>
+        <prettyName>Parse content</prettyName>
+        <unmodifiable>0</unmodifiable>
+        <classType>com.xpn.xwiki.objects.classes.BooleanClass</classType>
+      </parse>
+      <use>
+        <cache>0</cache>
+        <disabled>0</disabled>
+        <displayType>select</displayType>
+        <freeText>forbidden</freeText>
+        <largeStorage>0</largeStorage>
+        <multiSelect>0</multiSelect>
+        <name>use</name>
+        <number>3</number>
+        <prettyName>Use this extension</prettyName>
+        <relationalStorage>0</relationalStorage>
+        <separator> </separator>
+        <separators>|, </separators>
+        <size>1</size>
+        <unmodifiable>0</unmodifiable>
+        <values>currentPage|onDemand|always</values>
+        <classType>com.xpn.xwiki.objects.classes.StaticListClass</classType>
+      </use>
+    </class>
+    <property>
+      <cache>long</cache>
+    </property>
+    <property>
+      <code>.confluenceMacroDocEdit fieldset.confluenceMacroDocUrl {
+  padding: 2ex;
+  padding-bottom: 0;
+  border: 1px solid var(--legend-border-color, #e5e5e5);
+  margin-bottom: 19px;
+
+  dl.confluenceMacroDocPage {
+    display: grid;
+    grid-template-columns: 70% 30%;
+    grid-template-rows: auto auto;
+  }
+  dd.confluenceMacroDocPageRef {
+    grid-column: 1;
+  }
+  dt.confluenceMacroDocPageAnchor {
+    grid-row: 1;
+    margin-top:0;
+  }
+  dd  {
+    grid-row: 2;
+  }
+  .confluenceMacroDocPageAnchor {
+    margin-left: 2ex;
+    grid-column: 2;
+  }
+
+  legend {
+    margin-bottom: 0;
+    border-bottom: 0;
+    width: unset;
+    padding: 0 1ex;
+  }
+}
+</code>
+    </property>
+    <property>
+      <contentType>CSS</contentType>
+    </property>
+    <property>
+      <name>ConfluenceMacroDocSheetStyle</name>
+    </property>
+    <property>
+      <parse>0</parse>
+    </property>
+    <property>
+      <use>currentPage</use>
+    </property>
+  </object>
 </xwikidoc>

--- a/documentation-xwikiorg/documentation-xwikiorg-ui/src/main/resources/DocApp/Code/Confluence/ConfluenceMacroDocumentationListMacro.xml
+++ b/documentation-xwikiorg/documentation-xwikiorg-ui/src/main/resources/DocApp/Code/Confluence/ConfluenceMacroDocumentationListMacro.xml
@@ -296,12 +296,17 @@ Or with the parameters:
       <code>{{velocity}}
 #set ($locationParam = "$doc.space")
 #if ($wikimacro.parameters.reference != $NULL)
-    #set ($locationParam = $services.model.serialize($wikimacro.parameters.reference))
+    #set ($locationParam = $services.model.serialize($wikimacro.parameters.reference).replace('.WebHome', ''))
 #end
+#set ($sourceParameters = $escapetool.url({
+  'translationPrefix': 'platform.index.',
+  'className': 'DocApp.Code.Confluence.ConfluenceMacroDocumentationClass',
+  'location': $locationParam
+}))
 {{liveData
   source="liveTable"
-  properties="$wikimacro.parameters.columns"
-  sourceParameters="translationPrefix=platform.index.&amp;className=DocApp.Code.Confluence.ConfluenceMacroDocumentationClass&amp;location=$locationParam"
+  properties="$services.rendering.escape($wikimacro.parameters.columns, 'xwiki/2.1')"
+  sourceParameters="$sourceParameters"
 /}}
 {{/velocity}}</code>
     </property>

--- a/documentation-xwikiorg/documentation-xwikiorg-ui/src/main/resources/DocApp/Code/Confluence/ConfluencePluginDocumentationClass.xml
+++ b/documentation-xwikiorg/documentation-xwikiorg-ui/src/main/resources/DocApp/Code/Confluence/ConfluencePluginDocumentationClass.xml
@@ -148,7 +148,7 @@
       <classType>com.xpn.xwiki.objects.classes.DBListClass</classType>
     </pluginName>
     <prettyName>
-      <customDisplay>{{include reference="AppWithinMinutes.Title"/}}</customDisplay>
+      <customDisplay>{{include reference="DocApp.Code.Confluence.ConfluenceTitleDisplayer"/}}</customDisplay>
       <disabled>0</disabled>
       <hint>The plugin name</hint>
       <name>prettyName</name>

--- a/documentation-xwikiorg/documentation-xwikiorg-ui/src/main/resources/DocApp/Code/Confluence/ConfluenceTitleDisplayer.xml
+++ b/documentation-xwikiorg/documentation-xwikiorg-ui/src/main/resources/DocApp/Code/Confluence/ConfluenceTitleDisplayer.xml
@@ -1,0 +1,74 @@
+<?xml version="1.1" encoding="UTF-8"?>
+
+<!--
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+-->
+
+<xwikidoc version="1.6" reference="DocApp.Code.Confluence.ConfluenceTitleDisplayer" locale="">
+  <web>DocApp.Code.Confluence</web>
+  <name>ConfluenceTitleDisplayer</name>
+  <language/>
+  <defaultLanguage/>
+  <translation>0</translation>
+  <creator>xwiki:XWiki.Admin</creator>
+  <parent>DocApp.Code.Confluence.WebHome</parent>
+  <author>xwiki:XWiki.Admin</author>
+  <contentAuthor>xwiki:XWiki.Admin</contentAuthor>
+  <version>1.1</version>
+  <title>ConfluenceTitleDisplayer</title>
+  <comment/>
+  <minorEdit>false</minorEdit>
+  <syntaxId>xwiki/2.1</syntaxId>
+  <hidden>true</hidden>
+  <content>{{velocity}}
+## Code copied from AppWithinMinutes.Title
+## This is avoiding to set WebHome as the default value if the title is not set
+## This is fixing the issue in https://jira.xwiki.org/browse/XWIKI-24180
+## As soon as this issue is fixed, this page can be removed
+#if ($type == 'edit')
+  #set ($className = $object.getxWikiClass().name)
+  #if ($doc.fullName == $className)
+    ## We are editing the class so the title must be read from / written to the template document.
+    #set ($name = 'templateTitle')
+    #set ($value = $xwiki.getDocument("$stringtool.removeEnd($className, 'Class')Template").title)
+  #else
+    ## We are editing an application entry so the title must be read from / written to the current document.
+    #set ($name = 'title')
+    #set ($value = $tdoc.title)
+    ## BEGIN Customization - Avoid to put WebHome as default value for title if not set
+    ##if ("$!value" == '')
+      ##set ($value = $tdoc.documentReference.name)
+    ##end
+    ## END Customization
+  #end
+  {{html clean="false"}}
+  &lt;input type="text" name="$name" value="$!escapetool.xml($value)"
+    ## The default value for an AppWithinMinutes field should be optional so we make only the actual page title
+    ## mandatory and not the template title, which holds the default title value.
+    #if ($name == 'title' &amp;&amp; $xwiki.getSpacePreference('xwiki.title.mandatory') == 1)required #end
+    data-validation-value-missing="$escapetool.xml($services.localization.render('core.validation.required.message'))"/&gt;
+  {{/html}}
+#elseif ("$!type" != '')
+  ## Render the title of the current document.
+  {{html}}$tdoc.getRenderedTitle('xhtml/1.0'){{/html}}
+#else
+  The display mode is not specified!
+#end
+{{/velocity}}</content>
+</xwikidoc>


### PR DESCRIPTION
# Jira URL

https://op.xwiki.org/projects/documentation-application/work_packages/92/activity
https://op.xwiki.org/projects/documentation-application/work_packages/93/activity
https://op.xwiki.org/projects/documentation-application/work_packages/94/activity
https://op.xwiki.org/projects/documentation-application/work_packages/95/activity

# Changes

## Description

- Created a group to have a better visibility how work the link and the relations
- Customized the `AppWithinMinutes.Title` displayer to fix [#95](https://op.xwiki.org/projects/documentation-application/work_packages/95/activity)
- Reordered the some class field for better constancy
- Improved the Hints of some class fields.
- Did some fix for the `confluenceMacroDocumentationList` macro.

# Screenshots & Video

<img width="1252" height="292" alt="image" src="https://github.com/user-attachments/assets/106ed371-153e-4f0f-9e15-b3877ad80d04" />

# Expected merging strategy

* Prefers squash: Yes
* Backport on branches: No