### PR TITLE
Various improvements to the confluence macro documentation

### DIFF
--- a/documentation-xwikiorg/documentation-xwikiorg-ui/src/main/resources/DocApp/Code/Confluence/ConfluenceMacroDocumentationClass.xml
+++ b/documentation-xwikiorg/documentation-xwikiorg-ui/src/main/resources/DocApp/Code/Confluence/ConfluenceMacroDocumentationClass.xml
@@ -142,7 +142,7 @@
       <multiSelect>1</multiSelect>
       <name>equivXWikiFeatureName</name>
       <number>22</number>
-      <picker>0</picker>
+      <picker>1</picker>
       <prettyName>Alternative XWiki feature name</prettyName>
       <relationalStorage>0</relationalStorage>
       <separator>, </separator>
@@ -195,7 +195,7 @@
       <multiSelect>1</multiSelect>
       <name>equivXWikiFeaturePageAnchor</name>
       <number>24</number>
-      <picker>0</picker>
+      <picker>1</picker>
       <prettyName>Alternative XWiki feature documentation page anchor</prettyName>
       <relationalStorage>0</relationalStorage>
       <separator>, </separator>
@@ -220,7 +220,7 @@
       <multiSelect>1</multiSelect>
       <name>equivXWikiFeatureURL</name>
       <number>25</number>
-      <picker>0</picker>
+      <picker>1</picker>
       <prettyName>Alternative XWiki feature documentation URL</prettyName>
       <relationalStorage>0</relationalStorage>
       <separator>, </separator>
@@ -238,8 +238,8 @@
       <customDisplay/>
       <defaultValue/>
       <disabled>0</disabled>
-      <displayType>input</displayType>
-      <freeText>allowed</freeText>
+      <displayType>select</displayType>
+      <freeText/>
       <hint>How well the alternative feature in XWiki is equivalent to the Confluence feature. If the alternative XWiki feature brings the same features with no important limitations, we consider  full equivalence. If equivalent features lack or have limitations, depending on the situation, we consider partial equivalence.</hint>
       <largeStorage>0</largeStorage>
       <multiSelect>0</multiSelect>
@@ -306,8 +306,8 @@
       <customDisplay/>
       <defaultValue/>
       <disabled>0</disabled>
-      <displayType>input</displayType>
-      <freeText>allowed</freeText>
+      <displayType>select</displayType>
+      <freeText/>
       <hint>How well the Confluence macro is handled in XWiki. If all Confluence macro parameters are mapped to supported XWiki macro parameters, we consider this fully supported. If some parameters are not supported in XWiki, depending on the situation, we consider this partial.</hint>
       <largeStorage>0</largeStorage>
       <multiSelect>0</multiSelect>
@@ -345,13 +345,13 @@
       <defaultValue/>
       <disabled>0</disabled>
       <displayType>input</displayType>
-      <freeText/>
+      <freeText>allowed</freeText>
       <hint>URL to an extension required for importing this macro. You can give several comma-separated URLs.</hint>
       <largeStorage>0</largeStorage>
       <multiSelect>1</multiSelect>
       <name>requiredForImport</name>
       <number>15</number>
-      <picker>0</picker>
+      <picker>1</picker>
       <prettyName>Required for import documentation URL</prettyName>
       <relationalStorage>0</relationalStorage>
       <separator>, </separator>
@@ -370,13 +370,13 @@
       <defaultValue/>
       <disabled>0</disabled>
       <displayType>input</displayType>
-      <freeText/>
+      <freeText>allowed</freeText>
       <hint>ID of an extension required for importing this macro. You can give several comma-separated IDs.</hint>
       <largeStorage>0</largeStorage>
       <multiSelect>1</multiSelect>
       <name>requiredForImportId</name>
       <number>11</number>
-      <picker>0</picker>
+      <picker>1</picker>
       <prettyName>Required for import extension ID</prettyName>
       <relationalStorage>0</relationalStorage>
       <separator>, </separator>
@@ -421,7 +421,7 @@
       <defaultValue/>
       <disabled>0</disabled>
       <displayType>input</displayType>
-      <freeText>allowed</freeText>
+      <freeText/>
       <hint>Page of an extension required for importing this macro.</hint>
       <idField/>
       <largeStorage>0</largeStorage>
@@ -448,13 +448,13 @@
       <defaultValue/>
       <disabled>0</disabled>
       <displayType>input</displayType>
-      <freeText/>
+      <freeText>allowed</freeText>
       <hint>Anchor in the page of an extension required for importing this macro.</hint>
       <largeStorage>0</largeStorage>
       <multiSelect>1</multiSelect>
       <name>requiredForImportPageAnchor</name>
       <number>14</number>
-      <picker>0</picker>
+      <picker>1</picker>
       <prettyName>Required for import documentation page anchor</prettyName>
       <relationalStorage>0</relationalStorage>
       <separator>, </separator>
@@ -479,7 +479,7 @@
       <multiSelect>1</multiSelect>
       <name>requiredForUsage</name>
       <number>20</number>
-      <picker>0</picker>
+      <picker>1</picker>
       <prettyName>Required for usage documentation URL</prettyName>
       <relationalStorage>0</relationalStorage>
       <separator>, </separator>
@@ -504,7 +504,7 @@
       <multiSelect>1</multiSelect>
       <name>requiredForUsageId</name>
       <number>16</number>
-      <picker>0</picker>
+      <picker>1</picker>
       <prettyName>Required for usage extension ID</prettyName>
       <relationalStorage>0</relationalStorage>
       <separator>, </separator>
@@ -529,7 +529,7 @@
       <multiSelect>1</multiSelect>
       <name>requiredForUsageName</name>
       <number>17</number>
-      <picker>0</picker>
+      <picker>1</picker>
       <prettyName>Required for usage extension name</prettyName>
       <relationalStorage>0</relationalStorage>
       <separator>, </separator>
@@ -576,13 +576,13 @@
       <defaultValue/>
       <disabled>0</disabled>
       <displayType>input</displayType>
-      <freeText/>
+      <freeText>allowed</freeText>
       <hint>Documentation page anchor of an extension required for using this macro.</hint>
       <largeStorage>0</largeStorage>
       <multiSelect>1</multiSelect>
       <name>requiredForUsagePageAnchor</name>
       <number>19</number>
-      <picker>0</picker>
+      <picker>1</picker>
       <prettyName>Required for usage documentation page anchor</prettyName>
       <relationalStorage>0</relationalStorage>
       <separator>, </separator>
@@ -607,7 +607,7 @@
       <multiSelect>1</multiSelect>
       <name>xwikiId</name>
       <number>9</number>
-      <picker>0</picker>
+      <picker>1</picker>
       <prettyName>Import target XWiki ID</prettyName>
       <relationalStorage>0</relationalStorage>
       <separator>, </separator>
@@ -685,7 +685,7 @@
       <multiSelect>1</multiSelect>
       <name>xwikiPageAnchor</name>
       <number>6</number>
-      <picker>0</picker>
+      <picker>1</picker>
       <prettyName>Import target XWiki page anchor</prettyName>
       <relationalStorage>0</relationalStorage>
       <separator>, </separator>
@@ -710,7 +710,7 @@
       <multiSelect>1</multiSelect>
       <name>xwikiURL</name>
       <number>7</number>
-      <picker>0</picker>
+      <picker>1</picker>
       <prettyName>Import target XWiki URL</prettyName>
       <relationalStorage>0</relationalStorage>
       <separator>, </separator>

--- a/documentation-xwikiorg/documentation-xwikiorg-ui/src/main/resources/DocApp/Code/Confluence/ConfluenceMacroDocumentationClass.xml
+++ b/documentation-xwikiorg/documentation-xwikiorg-ui/src/main/resources/DocApp/Code/Confluence/ConfluenceMacroDocumentationClass.xml
@@ -51,7 +51,7 @@
       <disabled>0</disabled>
       <hint>Additional information</hint>
       <name>additionalInfo</name>
-      <number>25</number>
+      <number>28</number>
       <prettyName>Additional information</prettyName>
       <script/>
       <unmodifiable>0</unmodifiable>
@@ -92,11 +92,11 @@
       <customDisplay/>
       <disabled>0</disabled>
       <editor>---</editor>
-      <hint>How this macro would be implemented in XWiki and comparison with the corresponding feature</hint>
+      <hint>How this macro would be implemented in XWiki and comparison with the alternative feature</hint>
       <name>correspondingXWikiFeature</name>
-      <number>23</number>
+      <number>26</number>
       <picker>0</picker>
-      <prettyName>Corresponding XWiki feature description</prettyName>
+      <prettyName>Alternative XWiki feature description</prettyName>
       <restricted>0</restricted>
       <rows>5</rows>
       <size>40</size>
@@ -105,6 +105,56 @@
       <validationRegExp/>
       <classType>com.xpn.xwiki.objects.classes.TextAreaClass</classType>
     </correspondingXWikiFeature>
+    <equivXWikiFeatureId>
+      <cache>0</cache>
+      <customDisplay/>
+      <defaultValue/>
+      <disabled>0</disabled>
+      <displayType>input</displayType>
+      <freeText>allowed</freeText>
+      <hint>The extension id of a feature that should be used in XWiki for this feature regardless of the import. This should be only set if the value differs from "Import target XWiki ID" or for bridges to specify what the bridge uses and what to use in XWiki natively. You can give several comma-separated IDs.</hint>
+      <largeStorage>0</largeStorage>
+      <multiSelect>1</multiSelect>
+      <name>equivXWikiFeatureId</name>
+      <number>21</number>
+      <picker>1</picker>
+      <prettyName>Alternative XWiki feature extension ID</prettyName>
+      <relationalStorage>0</relationalStorage>
+      <separator>, </separator>
+      <separators>, |</separators>
+      <size>1</size>
+      <sort/>
+      <unmodifiable>0</unmodifiable>
+      <validationMessage/>
+      <validationRegExp/>
+      <values/>
+      <classType>com.xpn.xwiki.objects.classes.StaticListClass</classType>
+    </equivXWikiFeatureId>
+    <equivXWikiFeatureName>
+      <cache>0</cache>
+      <customDisplay/>
+      <defaultValue/>
+      <disabled>0</disabled>
+      <displayType>input</displayType>
+      <freeText>allowed</freeText>
+      <hint>The name of a feature that should be used in XWiki for this feature regardless of the import. This should be only set if the value differs from "Import target XWiki name" or for bridges to specify what the bridge uses and what to use in XWiki natively. You can give several comma-separated names.</hint>
+      <largeStorage>0</largeStorage>
+      <multiSelect>1</multiSelect>
+      <name>equivXWikiFeatureName</name>
+      <number>22</number>
+      <picker>0</picker>
+      <prettyName>Alternative XWiki feature name</prettyName>
+      <relationalStorage>0</relationalStorage>
+      <separator>, </separator>
+      <separators>, |</separators>
+      <size>1</size>
+      <sort/>
+      <unmodifiable>0</unmodifiable>
+      <validationMessage/>
+      <validationRegExp/>
+      <values/>
+      <classType>com.xpn.xwiki.objects.classes.StaticListClass</classType>
+    </equivXWikiFeatureName>
     <equivXWikiFeaturePage>
       <cache>0</cache>
       <classname/>
@@ -116,13 +166,13 @@
       <hint>The documentation of a feature that should be used in XWiki for this feature regardless of the import. This should be only set if the value differs from "Import target XWiki URL" or for bridges to specify what the bridge uses and what to use in XWiki natively.</hint>
       <idField/>
       <largeStorage>0</largeStorage>
-      <multiSelect>0</multiSelect>
+      <multiSelect>1</multiSelect>
       <name>equivXWikiFeaturePage</name>
-      <number>20</number>
+      <number>23</number>
       <picker>1</picker>
-      <prettyName>Corresponding  XWiki feature documentation page</prettyName>
+      <prettyName>Alternative XWiki feature documentation page</prettyName>
       <relationalStorage>0</relationalStorage>
-      <separator> </separator>
+      <separator>, </separator>
       <separators/>
       <size>1</size>
       <sort/>
@@ -134,49 +184,71 @@
       <classType>com.xpn.xwiki.objects.classes.PageClass</classType>
     </equivXWikiFeaturePage>
     <equivXWikiFeaturePageAnchor>
+      <cache>0</cache>
       <customDisplay/>
+      <defaultValue/>
       <disabled>0</disabled>
+      <displayType>input</displayType>
+      <freeText>allowed</freeText>
       <hint>The anchor in the documentation of a feature that should be used in XWiki for this feature regardless of the import.</hint>
+      <largeStorage>0</largeStorage>
+      <multiSelect>1</multiSelect>
       <name>equivXWikiFeaturePageAnchor</name>
-      <number>21</number>
-      <picker>1</picker>
-      <prettyName>Corresponding XWiki feature documentation page anchor</prettyName>
-      <size>30</size>
+      <number>24</number>
+      <picker>0</picker>
+      <prettyName>Alternative XWiki feature documentation page anchor</prettyName>
+      <relationalStorage>0</relationalStorage>
+      <separator>, </separator>
+      <separators>, |</separators>
+      <size>1</size>
+      <sort/>
       <unmodifiable>0</unmodifiable>
       <validationMessage/>
       <validationRegExp/>
-      <classType>com.xpn.xwiki.objects.classes.StringClass</classType>
+      <values/>
+      <classType>com.xpn.xwiki.objects.classes.StaticListClass</classType>
     </equivXWikiFeaturePageAnchor>
     <equivXWikiFeatureURL>
+      <cache>0</cache>
       <customDisplay/>
+      <defaultValue>29</defaultValue>
       <disabled>0</disabled>
-      <hint>The URL to the feature that should be used in XWiki for this feature regardless of the import. This should be only set if the value differs from "Import target XWiki URL" or for bridges to specify what the bridge uses and what to use in XWiki natively.</hint>
+      <displayType>input</displayType>
+      <freeText>allowed</freeText>
+      <hint>The URL to the feature that should be used in XWiki for this feature regardless of the import. This should be only set if the value differs from "Import target XWiki URL" or for bridges to specify what the bridge uses and what to use in XWiki natively. You can give several comma-separated URLs.</hint>
+      <largeStorage>0</largeStorage>
+      <multiSelect>1</multiSelect>
       <name>equivXWikiFeatureURL</name>
-      <number>22</number>
+      <number>25</number>
       <picker>0</picker>
-      <prettyName>Corresponding XWiki feature documentation URL</prettyName>
-      <size>30</size>
+      <prettyName>Alternative XWiki feature documentation URL</prettyName>
+      <relationalStorage>0</relationalStorage>
+      <separator>, </separator>
+      <separators>, |</separators>
+      <size>1</size>
+      <sort/>
       <unmodifiable>0</unmodifiable>
       <validationMessage/>
       <validationRegExp/>
-      <classType>com.xpn.xwiki.objects.classes.StringClass</classType>
+      <values/>
+      <classType>com.xpn.xwiki.objects.classes.StaticListClass</classType>
     </equivXWikiFeatureURL>
     <functionalEquivalenceQualifier>
       <cache>0</cache>
       <customDisplay/>
       <defaultValue/>
       <disabled>0</disabled>
-      <displayType>select</displayType>
-      <freeText/>
-      <hint>How well the corresponding feature in XWiki is equivalent to the Confluence feature. If the corresponding XWiki feature brings the same features with no important limitations, we consider  full equivalence. If corresponding features lack or have limitations, depending on the situation, we consider partial equivalence.</hint>
+      <displayType>input</displayType>
+      <freeText>allowed</freeText>
+      <hint>How well the alternative feature in XWiki is equivalent to the Confluence feature. If the alternative XWiki feature brings the same features with no important limitations, we consider  full equivalence. If equivalent features lack or have limitations, depending on the situation, we consider partial equivalence.</hint>
       <largeStorage>0</largeStorage>
       <multiSelect>0</multiSelect>
       <name>functionalEquivalenceQualifier</name>
-      <number>6</number>
+      <number>27</number>
       <picker>1</picker>
       <prettyName>Functional Equivalence Qualifier</prettyName>
       <relationalStorage>0</relationalStorage>
-      <separator> </separator>
+      <separator>, </separator>
       <separators>|, </separators>
       <size>1</size>
       <sort/>
@@ -218,7 +290,7 @@
       <editor>---</editor>
       <hint>Details on how (well) this Confluence macro is imported</hint>
       <name>handlingDetails</name>
-      <number>24</number>
+      <number>29</number>
       <picker>0</picker>
       <prettyName>Import handling details</prettyName>
       <restricted>0</restricted>
@@ -234,13 +306,13 @@
       <customDisplay/>
       <defaultValue/>
       <disabled>0</disabled>
-      <displayType>select</displayType>
+      <displayType>input</displayType>
       <freeText>allowed</freeText>
       <hint>How well the Confluence macro is handled in XWiki. If all Confluence macro parameters are mapped to supported XWiki macro parameters, we consider this fully supported. If some parameters are not supported in XWiki, depending on the situation, we consider this partial.</hint>
       <largeStorage>0</largeStorage>
       <multiSelect>0</multiSelect>
       <name>importSupportQualifier</name>
-      <number>5</number>
+      <number>8</number>
       <picker>1</picker>
       <prettyName>Import Quality Qualifier</prettyName>
       <relationalStorage>0</relationalStorage>
@@ -257,7 +329,7 @@
     <prettyName>
       <customDisplay>{{include reference="DocApp.Code.Confluence.ConfluenceTitleDisplayer"/}}</customDisplay>
       <disabled>0</disabled>
-      <hint>The user-friendly macro name as it is presented in confluence (different from the confluence ID which is the technical name)</hint>
+      <hint>The user-friendly macro name as it is presented in Confluence (different from the confluence ID which is the technical name)</hint>
       <name>prettyName</name>
       <number>1</number>
       <prettyName>User-friendly macro name</prettyName>
@@ -268,33 +340,80 @@
       <classType>com.xpn.xwiki.objects.classes.ComputedFieldClass</classType>
     </prettyName>
     <requiredForImport>
+      <cache>0</cache>
       <customDisplay/>
+      <defaultValue/>
       <disabled>0</disabled>
-      <hint>URL to an extension required for importing this macro.</hint>
+      <displayType>input</displayType>
+      <freeText/>
+      <hint>URL to an extension required for importing this macro. You can give several comma-separated URLs.</hint>
+      <largeStorage>0</largeStorage>
+      <multiSelect>1</multiSelect>
       <name>requiredForImport</name>
-      <number>14</number>
+      <number>15</number>
       <picker>0</picker>
       <prettyName>Required for import documentation URL</prettyName>
-      <size>30</size>
+      <relationalStorage>0</relationalStorage>
+      <separator>, </separator>
+      <separators>, |</separators>
+      <size>1</size>
+      <sort/>
       <unmodifiable>0</unmodifiable>
       <validationMessage/>
       <validationRegExp/>
-      <classType>com.xpn.xwiki.objects.classes.StringClass</classType>
+      <values/>
+      <classType>com.xpn.xwiki.objects.classes.StaticListClass</classType>
     </requiredForImport>
     <requiredForImportId>
+      <cache>0</cache>
       <customDisplay/>
+      <defaultValue/>
       <disabled>0</disabled>
-      <hint>ID of an extension required for importing this macro</hint>
+      <displayType>input</displayType>
+      <freeText/>
+      <hint>ID of an extension required for importing this macro. You can give several comma-separated IDs.</hint>
+      <largeStorage>0</largeStorage>
+      <multiSelect>1</multiSelect>
       <name>requiredForImportId</name>
       <number>11</number>
       <picker>0</picker>
       <prettyName>Required for import extension ID</prettyName>
-      <size>30</size>
+      <relationalStorage>0</relationalStorage>
+      <separator>, </separator>
+      <separators>, |</separators>
+      <size>1</size>
+      <sort/>
       <unmodifiable>0</unmodifiable>
       <validationMessage/>
       <validationRegExp/>
-      <classType>com.xpn.xwiki.objects.classes.StringClass</classType>
+      <values/>
+      <classType>com.xpn.xwiki.objects.classes.StaticListClass</classType>
     </requiredForImportId>
+    <requiredForImportName>
+      <cache>0</cache>
+      <customDisplay/>
+      <defaultValue/>
+      <disabled>0</disabled>
+      <displayType>input</displayType>
+      <freeText>allowed</freeText>
+      <hint>User-friendly name of the extension required for importing the macro. You can give several comma-separated names.</hint>
+      <largeStorage>0</largeStorage>
+      <multiSelect>1</multiSelect>
+      <name>requiredForImportName</name>
+      <number>12</number>
+      <picker>1</picker>
+      <prettyName> Required for import extension name</prettyName>
+      <relationalStorage>0</relationalStorage>
+      <separator>, </separator>
+      <separators>, |</separators>
+      <size>1</size>
+      <sort/>
+      <unmodifiable>0</unmodifiable>
+      <validationMessage/>
+      <validationRegExp/>
+      <values/>
+      <classType>com.xpn.xwiki.objects.classes.StaticListClass</classType>
+    </requiredForImportName>
     <requiredForImportPage>
       <cache>0</cache>
       <classname/>
@@ -302,17 +421,17 @@
       <defaultValue/>
       <disabled>0</disabled>
       <displayType>input</displayType>
-      <freeText/>
+      <freeText>allowed</freeText>
       <hint>Page of an extension required for importing this macro.</hint>
       <idField/>
       <largeStorage>0</largeStorage>
-      <multiSelect>0</multiSelect>
+      <multiSelect>1</multiSelect>
       <name>requiredForImportPage</name>
       <number>13</number>
       <picker>1</picker>
       <prettyName>Required for import documentation page</prettyName>
       <relationalStorage>0</relationalStorage>
-      <separator> </separator>
+      <separator>, </separator>
       <separators/>
       <size>1</size>
       <sort/>
@@ -324,60 +443,104 @@
       <classType>com.xpn.xwiki.objects.classes.PageClass</classType>
     </requiredForImportPage>
     <requiredForImportPageAnchor>
+      <cache>0</cache>
       <customDisplay/>
+      <defaultValue/>
       <disabled>0</disabled>
+      <displayType>input</displayType>
+      <freeText/>
       <hint>Anchor in the page of an extension required for importing this macro.</hint>
+      <largeStorage>0</largeStorage>
+      <multiSelect>1</multiSelect>
       <name>requiredForImportPageAnchor</name>
-      <number>13</number>
-      <picker>1</picker>
+      <number>14</number>
+      <picker>0</picker>
       <prettyName>Required for import documentation page anchor</prettyName>
-      <size>30</size>
+      <relationalStorage>0</relationalStorage>
+      <separator>, </separator>
+      <separators>, |</separators>
+      <size>1</size>
+      <sort/>
       <unmodifiable>0</unmodifiable>
       <validationMessage/>
       <validationRegExp/>
-      <classType>com.xpn.xwiki.objects.classes.StringClass</classType>
+      <values/>
+      <classType>com.xpn.xwiki.objects.classes.StaticListClass</classType>
     </requiredForImportPageAnchor>
     <requiredForUsage>
+      <cache>0</cache>
       <customDisplay/>
+      <defaultValue/>
       <disabled>0</disabled>
-      <hint>URL to the documentation of a extension required for using the imported macro.</hint>
+      <displayType>input</displayType>
+      <freeText>allowed</freeText>
+      <hint>URL to the documentation of a extension required for using the imported macro. You can give several comma-separated URLs.</hint>
+      <largeStorage>0</largeStorage>
+      <multiSelect>1</multiSelect>
       <name>requiredForUsage</name>
-      <number>19</number>
+      <number>20</number>
       <picker>0</picker>
       <prettyName>Required for usage documentation URL</prettyName>
-      <size>30</size>
+      <relationalStorage>0</relationalStorage>
+      <separator>, </separator>
+      <separators>, |</separators>
+      <size>1</size>
+      <sort/>
       <unmodifiable>0</unmodifiable>
       <validationMessage/>
       <validationRegExp/>
-      <classType>com.xpn.xwiki.objects.classes.StringClass</classType>
+      <values/>
+      <classType>com.xpn.xwiki.objects.classes.StaticListClass</classType>
     </requiredForUsage>
     <requiredForUsageId>
+      <cache>0</cache>
       <customDisplay/>
+      <defaultValue>29</defaultValue>
       <disabled>0</disabled>
-      <hint>ID of an extension required for using this macro</hint>
+      <displayType>input</displayType>
+      <freeText/>
+      <hint>ID of an extension required for using this macro. You can give several comma-separated IDs.</hint>
+      <largeStorage>0</largeStorage>
+      <multiSelect>1</multiSelect>
       <name>requiredForUsageId</name>
-      <number>15</number>
+      <number>16</number>
       <picker>0</picker>
       <prettyName>Required for usage extension ID</prettyName>
-      <size>30</size>
+      <relationalStorage>0</relationalStorage>
+      <separator>, </separator>
+      <separators>, |</separators>
+      <size>1</size>
+      <sort/>
       <unmodifiable>0</unmodifiable>
       <validationMessage/>
       <validationRegExp/>
-      <classType>com.xpn.xwiki.objects.classes.StringClass</classType>
+      <values/>
+      <classType>com.xpn.xwiki.objects.classes.StaticListClass</classType>
     </requiredForUsageId>
     <requiredForUsageName>
+      <cache>0</cache>
       <customDisplay/>
+      <defaultValue/>
       <disabled>0</disabled>
-      <hint>Name of an extension required for using this macro</hint>
+      <displayType>input</displayType>
+      <freeText/>
+      <hint>Name of an extension required for using this macro. You can give several comma-separated names.</hint>
+      <largeStorage>0</largeStorage>
+      <multiSelect>1</multiSelect>
       <name>requiredForUsageName</name>
-      <number>16</number>
-      <picker>1</picker>
+      <number>17</number>
+      <picker>0</picker>
       <prettyName>Required for usage extension name</prettyName>
-      <size>30</size>
+      <relationalStorage>0</relationalStorage>
+      <separator>, </separator>
+      <separators>, |</separators>
+      <size>1</size>
+      <sort/>
       <unmodifiable>0</unmodifiable>
       <validationMessage/>
       <validationRegExp/>
-      <classType>com.xpn.xwiki.objects.classes.StringClass</classType>
+      <values/>
+      <classType>com.xpn.xwiki.objects.classes.StaticListClass</classType>
     </requiredForUsageName>
     <requiredForUsagePage>
       <cache>0</cache>
@@ -390,15 +553,15 @@
       <hint>Documentation page of an extension required for using this macro.</hint>
       <idField/>
       <largeStorage>0</largeStorage>
-      <multiSelect>0</multiSelect>
+      <multiSelect>1</multiSelect>
       <name>requiredForUsagePage</name>
-      <number>17</number>
+      <number>18</number>
       <picker>1</picker>
       <prettyName>Required for usage documentation page</prettyName>
       <relationalStorage>0</relationalStorage>
-      <separator> </separator>
+      <separator>, </separator>
       <separators/>
-      <size>1</size>
+      <size>28</size>
       <sort/>
       <sql/>
       <unmodifiable>0</unmodifiable>
@@ -408,33 +571,80 @@
       <classType>com.xpn.xwiki.objects.classes.PageClass</classType>
     </requiredForUsagePage>
     <requiredForUsagePageAnchor>
+      <cache>0</cache>
       <customDisplay/>
+      <defaultValue/>
       <disabled>0</disabled>
+      <displayType>input</displayType>
+      <freeText/>
       <hint>Documentation page anchor of an extension required for using this macro.</hint>
+      <largeStorage>0</largeStorage>
+      <multiSelect>1</multiSelect>
       <name>requiredForUsagePageAnchor</name>
-      <number>18</number>
-      <picker>1</picker>
+      <number>19</number>
+      <picker>0</picker>
       <prettyName>Required for usage documentation page anchor</prettyName>
-      <size>30</size>
+      <relationalStorage>0</relationalStorage>
+      <separator>, </separator>
+      <separators>, |</separators>
+      <size>1</size>
+      <sort/>
       <unmodifiable>0</unmodifiable>
       <validationMessage/>
-      <validationRegExp/>
-      <classType>com.xpn.xwiki.objects.classes.StringClass</classType>
+      <validationRegExp>, </validationRegExp>
+      <values/>
+      <classType>com.xpn.xwiki.objects.classes.StaticListClass</classType>
     </requiredForUsagePageAnchor>
     <xwikiId>
+      <cache>0</cache>
       <customDisplay/>
+      <defaultValue/>
       <disabled>0</disabled>
-      <hint>The import target macro, if applicable</hint>
+      <displayType>input</displayType>
+      <freeText>allowed</freeText>
+      <hint>The import target macro, if applicable. You can give several comma-separated macros.</hint>
+      <largeStorage>0</largeStorage>
+      <multiSelect>1</multiSelect>
       <name>xwikiId</name>
-      <number>7</number>
+      <number>9</number>
       <picker>0</picker>
       <prettyName>Import target XWiki ID</prettyName>
-      <size>30</size>
+      <relationalStorage>0</relationalStorage>
+      <separator>, </separator>
+      <separators>, |</separators>
+      <size>1</size>
+      <sort/>
       <unmodifiable>0</unmodifiable>
       <validationMessage/>
       <validationRegExp/>
-      <classType>com.xpn.xwiki.objects.classes.StringClass</classType>
+      <values/>
+      <classType>com.xpn.xwiki.objects.classes.StaticListClass</classType>
     </xwikiId>
+    <xwikiName>
+      <cache>0</cache>
+      <customDisplay/>
+      <defaultValue/>
+      <disabled>0</disabled>
+      <displayType>input</displayType>
+      <freeText>allowed</freeText>
+      <hint>The (user-friendly) name of the import target, if applicable. You can give several comma-separated names.</hint>
+      <largeStorage>0</largeStorage>
+      <multiSelect>1</multiSelect>
+      <name>xwikiName</name>
+      <number>5</number>
+      <picker>1</picker>
+      <prettyName>Import target XWiki name</prettyName>
+      <relationalStorage>0</relationalStorage>
+      <separator>, </separator>
+      <separators>, |</separators>
+      <size>1</size>
+      <sort/>
+      <unmodifiable>0</unmodifiable>
+      <validationMessage/>
+      <validationRegExp/>
+      <values/>
+      <classType>com.xpn.xwiki.objects.classes.StaticListClass</classType>
+    </xwikiName>
     <xwikiPage>
       <cache>0</cache>
       <classname/>
@@ -442,17 +652,17 @@
       <defaultValue/>
       <disabled>0</disabled>
       <displayType>input</displayType>
-      <freeText/>
+      <freeText>allowed</freeText>
       <hint>The import target macro documentation, if applicable.</hint>
       <idField/>
       <largeStorage>0</largeStorage>
-      <multiSelect>0</multiSelect>
+      <multiSelect>1</multiSelect>
       <name>xwikiPage</name>
-      <number>8</number>
+      <number>10</number>
       <picker>1</picker>
       <prettyName>Import target XWiki page</prettyName>
       <relationalStorage>0</relationalStorage>
-      <separator> </separator>
+      <separator>, </separator>
       <separators/>
       <size>1</size>
       <sort/>
@@ -464,32 +674,54 @@
       <classType>com.xpn.xwiki.objects.classes.PageClass</classType>
     </xwikiPage>
     <xwikiPageAnchor>
+      <cache>0</cache>
       <customDisplay/>
+      <defaultValue/>
       <disabled>0</disabled>
+      <displayType>input</displayType>
+      <freeText>allowed</freeText>
       <hint>The anchor in the import target macro documentation, if applicable.</hint>
+      <largeStorage>0</largeStorage>
+      <multiSelect>1</multiSelect>
       <name>xwikiPageAnchor</name>
-      <number>9</number>
-      <picker>1</picker>
+      <number>6</number>
+      <picker>0</picker>
       <prettyName>Import target XWiki page anchor</prettyName>
-      <size>30</size>
+      <relationalStorage>0</relationalStorage>
+      <separator>, </separator>
+      <separators>, |</separators>
+      <size>1</size>
+      <sort/>
       <unmodifiable>0</unmodifiable>
       <validationMessage/>
       <validationRegExp/>
-      <classType>com.xpn.xwiki.objects.classes.StringClass</classType>
+      <values/>
+      <classType>com.xpn.xwiki.objects.classes.StaticListClass</classType>
     </xwikiPageAnchor>
     <xwikiURL>
+      <cache>0</cache>
       <customDisplay/>
+      <defaultValue/>
       <disabled>0</disabled>
-      <hint>The import target macro documentation, if applicable.</hint>
+      <displayType>input</displayType>
+      <freeText>allowed</freeText>
+      <hint>The import target macro documentation URL, if applicable. You can give several comma-separated URLs.</hint>
+      <largeStorage>0</largeStorage>
+      <multiSelect>1</multiSelect>
       <name>xwikiURL</name>
-      <number>10</number>
+      <number>7</number>
       <picker>0</picker>
       <prettyName>Import target XWiki URL</prettyName>
-      <size>30</size>
+      <relationalStorage>0</relationalStorage>
+      <separator>, </separator>
+      <separators>, |</separators>
+      <size>1</size>
+      <sort/>
       <unmodifiable>0</unmodifiable>
       <validationMessage/>
       <validationRegExp/>
-      <classType>com.xpn.xwiki.objects.classes.StringClass</classType>
+      <values/>
+      <classType>com.xpn.xwiki.objects.classes.StaticListClass</classType>
     </xwikiURL>
   </class>
   <object>

--- a/documentation-xwikiorg/documentation-xwikiorg-ui/src/main/resources/DocApp/Code/Confluence/ConfluenceMacroDocumentationClassSheet.xml
+++ b/documentation-xwikiorg/documentation-xwikiorg-ui/src/main/resources/DocApp/Code/Confluence/ConfluenceMacroDocumentationClassSheet.xml
@@ -37,8 +37,110 @@
   <syntaxId>xwiki/2.1</syntaxId>
   <hidden>true</hidden>
   <content>{{velocity}}
+  ## .get(i) throws instead of returning null on those lists unfortunately,
+  ## hence the following macros reading variables
+  #macro (readXWikiListVariables $index)
+    #set ($xwikiPage = $NULL)
+    #if ($index &lt; $xwikiPages.size())
+      #set ($xwikiPage = $xwikiPages.get($index))
+    #end
+    #set ($xwikiPageAnchor = $NULL)
+    #if ($index &lt; $xwikiPageAnchors.size())
+      #set ($xwikiPageAnchor = $xwikiPageAnchors.get($index))
+    #end
+    #set ($xwikiURL = $NULL)
+    #if ($index &lt; $xwikiURLs.size())
+      #set ($xwikiURL = $xwikiURLs.get($index))
+    #end
+  #end
+  #macro (readRequiredForImportVariables $index)
+    #set ($requiredForImportName = $NULL)
+    #if ($index &lt; $requiredForImportNames.size())
+      #set ($requiredForImportName = $requiredForImportNames.get($index))
+    #end
+    #set ($requiredForImportURL = $NULL)
+    #if ($index &lt; $requiredForImportURLs.size())
+      #set ($requiredForImportURL = $requiredForImportURLs.get($index))
+    #end
+    #set ($requiredForImportPage = $NULL)
+    #if ($index &lt; $requiredForImportPages.size())
+      #set ($requiredForImportPage = $requiredForImportPages.get($index))
+    #end
+    #set ($requiredForImportPageAnchor = $NULL)
+    #if ($index &lt; $requiredForImportPageAnchors.size())
+      #set ($requiredForImportPageAnchor = $requiredForImportPageAnchors.get($index))
+    #end
+    #set ($requiredForImportId = $NULL)
+    #if ($index &lt; $requiredForImportIds.size())
+      #set ($requiredForImportId = $requiredForImportIds.get($index))
+    #end
+  #end
+  #macro (readRequiredForUsageVariables $index)
+    #set ($requiredForUsageName = $NULL)
+    #if ($index &lt; $requiredForUsageNames.size())
+      #set ($requiredForUsageName = $requiredForUsageNames.get($index))
+    #end
+    #set ($requiredForUsageURL = $NULL)
+    #if ($index &lt; $requiredForUsageURLs.size())
+      #set ($requiredForUsageURL = $requiredForUsageURLs.get($index))
+    #end
+    #set ($requiredForUsagePage = $NULL)
+    #if ($index &lt; $requiredForUsagePages.size())
+      #set ($requiredForUsagePage = $requiredForUsagePages.get($index))
+    #end
+    #set ($requiredForUsagePageAnchor = $NULL)
+    #if ($index &lt; $requiredForUsagePageAnchors.size())
+      #set ($requiredForUsagePageAnchor = $requiredForUsagePageAnchors.get($index))
+    #end
+    #set ($requiredForUsageId = $NULL)
+    #if ($index &lt; $requiredForUsageIds.size())
+      #set ($requiredForUsageId = $requiredForUsageIds.get($index))
+    #end
+  #end
+  #macro (readEquivXWikiFeatureVariables $index)
+    #set ($equivXWikiFeatureName = $NULL)
+    #if ($index &lt; $equivXWikiFeatureNames.size())
+      #set ($equivXWikiFeatureName = $equivXWikiFeatureNames.get($index))
+    #end
+    #set ($equivXWikiFeatureURL = $NULL)
+    #if ($index &lt; $equivXWikiFeatureURLs.size())
+      #set ($equivXWikiFeatureURL = $equivXWikiFeatureURLs.get($index))
+    #end
+    #set ($equivXWikiFeaturePage = $NULL)
+    #if ($index &lt; $equivXWikiFeaturePages.size())
+      #set ($equivXWikiFeaturePage = $equivXWikiFeaturePages.get($index))
+    #end
+    #set ($equivXWikiFeaturePageAnchor = $NULL)
+    #if ($index &lt; $equivXWikiFeaturePageAnchors.size())
+      #set ($equivXWikiFeaturePageAnchor = $equivXWikiFeaturePageAnchors.get($index))
+    #end
+    #set ($equivXWikiFeatureId = $NULL)
+    #if ($index &lt; $equivXWikiFeatureIds.size())
+      #set ($equivXWikiFeatureId = $equivXWikiFeatureIds.get($index))
+    #end
+  #end
+  #macro (maybeCommaOrAnd)
+    #if (!$foreach.first)
+      #if ($foreach.last) and#else,#end ##
+    #end
+  #end
+  #macro (renderXWikiMacroList)
+    #if ($handling == 'conversionToSyntax' || $xwikiIds.isEmpty())
+      some syntax##
+    #else
+      #set ($xwikiIdContent = "")
+      #foreach ($xwikiId in $xwikiIds)
+        #maybeCommaOrAnd()
+        #readXWikiListVariables($foreach.index)
+        #renderMaybeLink($xwikiPage, $xwikiPageAnchor, $xwikiURL, "#renderAsCode($xwikiId)")##
+      #end
+    #end
+  #end
+  #macro (renderAsCode $s)
+    {{code language="none" source="string:$services.rendering.escape($s, 'xwiki/2.1')"/}}##
+  #end
   #macro (renderMaybeLink $page $anchor $url $content)
-    #if ($url == '-' || $url == '?' || $url == '')
+    #if ($url == '-' || $url == '?' || $url == '' || $url == $NULL)
       #set ($link = $page)
       #if ("$!anchor" != '')
         #set ($link = "$services.rendering.escape($link, 'xwiki/2.1')||anchor='$services.rendering.escape($anchor, 'xwiki/2.1')'")
@@ -55,17 +157,36 @@
     #end
   #end
   ##
-  #macro (renderLinkEdit $class $urlPropertyName $pagePropertyName $pageAnchorPropertyName)
+  #macro (renderLinkEdit $class $urlPropertyName $pagePropertyName $pageAnchorPropertyName $extensionIdPropertyName $extensionNamePropertyName)
     #set ($macro.pageProperty = $class.get($pagePropertyName))
     #set ($macro.pageAnchorProperty = $class.get($pageAnchorPropertyName))
     #set ($macro.urlProperty = $class.get($urlPropertyName))
+    #set ($macro.extensionIdProperty = $class.get($extensionIdPropertyName))
+    #set ($macro.extensionNameProperty = $class.get($extensionNamePropertyName))
     &lt;fieldset class="confluenceMacroDocUrl"&gt;
       &lt;legend&gt;$macro.pageProperty.prettyName.replace(' page', '')&lt;/legend&gt;
+      &lt;dl&gt;
+        &lt;dt class="confluenceMacroDocExtensionId"&gt;
+          &lt;label for="${class.name}_0_${macro.extensionIdProperty.name}"&gt;$macro.extensionIdProperty.prettyName&lt;/label&gt;
+          &lt;span class="xHint"&gt;$!macro.extensionIdProperty.hint&lt;/span&gt;
+        &lt;/dt&gt;
+        &lt;dd class="confluenceMacroDocExtensionId"&gt;
+          {{/html}}$doc.display($extensionIdPropertyName){{html clean="false"}}
+        &lt;/dd&gt;
+        &lt;dt class="confluenceMacroDocExtensionName"&gt;
+          &lt;label for="${class.name}_0_${macro.extensionNameProperty.name}"&gt;$macro.extensionNameProperty.prettyName&lt;/label&gt;
+          &lt;span class="xHint"&gt;$!macro.extensionNameProperty.hint&lt;/span&gt;
+        &lt;/dt&gt;
+        &lt;dd class="confluenceMacroDocExtensionId"&gt;
+          {{/html}}$doc.display($extensionNamePropertyName){{html clean="false"}}
+        &lt;/dd&gt;
+      &lt;/dl&gt;
+      &lt;hr /&gt;
       &lt;dl class="confluenceMacroDocPage"&gt;
         &lt;dt class="confluenceMacroDocPageRef"&gt;
           &lt;label for="${class.name}_0_${macro.pageProperty.name}"&gt;$macro.pageProperty.prettyName&lt;/label&gt;
           &lt;span class="xHint"&gt;$!macro.pageProperty.hint&lt;/span&gt;
-          &lt;span class="xHint"&gt;Replace the URL in case of the target page is into the same wiki.&lt;/span&gt;
+          &lt;span class="xHint"&gt;Use this field if the document to link is on this XWiki instance.&lt;/span&gt;
         &lt;/dt&gt;
         &lt;dd class="confluenceMacroDocPageRef"&gt;
           {{/html}}$doc.display($pagePropertyName){{html clean="false"}}
@@ -79,6 +200,7 @@
           {{/html}}$doc.display($pageAnchorPropertyName){{html clean="false"}}
         &lt;/dd&gt;
       &lt;/dl&gt;
+      &lt;p style="text-align:center; opacity: 0.8"&gt;- OR -&lt;/p&gt;
       &lt;dl&gt;
         &lt;dt&gt;
           &lt;label for="${class.name}_0_${macro.urlProperty.name}"&gt;$macro.urlProperty.prettyName&lt;/label&gt;
@@ -115,10 +237,10 @@
       {{html clean="false"}}
         &lt;div class="xform confluenceMacroDocEdit" &gt;
           #set ($linkPropertiesMap = {
-            'xwikiURL': ['xwikiPage', 'xwikiPageAnchor'],
-            'requiredForImport': ['requiredForImportPage', 'requiredForImportPageAnchor'],
-            'requiredForUsage': ['requiredForUsagePage', 'requiredForUsagePageAnchor'],
-            'equivXWikiFeatureURL': ['equivXWikiFeaturePage', 'equivXWikiFeaturePageAnchor']
+            'xwikiURL': ['xwikiPage', 'xwikiPageAnchor', 'xwikiId', 'xwikiName'],
+            'requiredForImport': ['requiredForImportPage', 'requiredForImportPageAnchor', 'requiredForImportId', 'requiredForImportName'],
+            'requiredForUsage': ['requiredForUsagePage', 'requiredForUsagePageAnchor', 'requiredForUsageId', 'requiredForUsageName'],
+            'equivXWikiFeatureURL': ['equivXWikiFeaturePage', 'equivXWikiFeaturePageAnchor', 'equivXWikiFeatureId', 'equivXWikiFeatureName']
           })
           #set ($propertiesForLink = [])
           #set ($discard = $propertiesForLink.addAll($linkPropertiesMap.keySet()))
@@ -129,7 +251,7 @@
             #if ($propertiesForLink.contains($property.name))
               #if ($linkPropertiesMap.containsKey($property.name))
                 #set ($linkPropertyValue = $linkPropertiesMap[$property.name])
-                #renderLinkEdit($class $property.name, $linkPropertyValue[0], $linkPropertyValue[1])
+                #renderLinkEdit($class $property.name, $linkPropertyValue[0], $linkPropertyValue[1], $linkPropertyValue[2], $linkPropertyValue[3])
               #end
             #else
               #if ($foreach.first || $propertiesForLink.contains($class.properties[$foreach.count - 2].name))
@@ -152,93 +274,108 @@
     #else
       #set ($importSupportQualifier = $macroObj.getValue('importSupportQualifier'))
       #if ($importSupportQualifier == 'partial')
+
         {{warning}}
           The import of this macro may be incomplete.
         {{/warning}}
-
       #elseif ($importSupportQualifier == 'no')
+
         {{error}}
           The import of this macro is not supported: important features will be missing.
         {{/error}}
-
       #end
       #set ($functionalEquivalenceQualifier = $macroObj.getValue('functionalEquivalenceQualifier'))
       #if ($functionalEquivalenceQualifier == 'partial')
+
         {{warning}}
-          This macro's equivalent feature in XWiki may lack features.
+          This macro's alternative feature in XWiki may lack features.
         {{/warning}}
-
       #elseif ($functionalEquivalenceQualifier == 'no')
-        {{error}}
-          Important features will be missing in XWiki's equivalent feature.
-        {{/error}}
 
+        {{error}}
+          Important features will be missing in XWiki's alternative feature.
+        {{/error}}
       #end
       #set ($confluenceURL = $macroObj.getValue('confluenceURL'))
-      The #renderMaybeLink('' '' $confluenceURL, '{{code language="none" source="script:confluenceId"/}}') Confluence macro ##
+
+      The #renderMaybeLink('' '' $confluenceURL, "#renderAsCode($confluenceId)") Confluence macro ##
       #set ($handling = $macroObj.getValue('handling'))
-      #set ($xwikiId = $macroObj.getValue('xwikiId'))
-      #set ($xwikiURL = $macroObj.getValue('xwikiURL'))
-      #set ($xwikiPage = $macroObj.getValue('xwikiPage'))
-      #set ($xwikiPageAnchor = $macroObj.getValue('xwikiPageAnchor'))
-      #if ($handling.startsWith('conversion'))
-        #if ($handling == 'conversionToSyntax' || "$!xwikiId" == '')
-          #set ($xwikiIdContent = 'some syntax') ##
-        #else
-          #set ($xwikiIdContent = 'the {{code language="none" source="script:xwikiId"/}} macro') ##
-        #end
-        is converted to ##
-        #renderMaybeLink($xwikiPage, $xwikiPageAnchor, $xwikiURL, $xwikiIdContent) ##
+      #set ($xwikiIds = $macroObj.getValue('xwikiId'))
+      #set ($xwikiURLs = $macroObj.getValue('xwikiURL'))
+      #set ($xwikiPages = $macroObj.getValue('xwikiPage'))
+      #set ($xwikiPageAnchors = $macroObj.getValue('xwikiPageAnchor'))
+      #if ($handling.startsWith('conversion') || $handling == 'direct')
+        is converted to the #renderXWikiMacroList() macro#if ($xwikiIds.size() &gt; 1)s#end.
       #elseif ($handling == 'bridge')
-        is covered by the ##
-        #set ($linkContent = '{{code language="none" source="script:xwikiId"/}} bridge macro')
-        #renderMaybeLink($xwikiPage, $xwikiPageAnchor, $xwikiURL, $linkContent) ##
-      #elseif ($handling == 'direct')
-        is imported ##
-        #renderMaybeLink($xwikiPage, $xwikiPageAnchor, $xwikiURL, 'as-is') ##
+        is covered by the #renderXWikiMacroList() bridge#if ($xwikiIds.size() &gt; 1)s#end.
       #elseif ($handling == 'drop')
-        is dropped##
+        is dropped.
       #else
-        uses ##
-        #renderMaybeLink($xwikiPage, $xwikiPageAnchor, $xwikiURL, $handling) ##
-      #end##
-      #if ($handling != 'drop')
-        #set ($requiredForUsageURL = $macroObj.getValue('requiredForUsage'))
-        #set ($requiredForUsageName = $macroObj.getValue('requiredForUsageName'))
-        #set ($requiredForUsagePage = $macroObj.getValue('requiredForUsagePage'))
-        #if (("$!requiredForUsageName" == '' &amp;&amp; "$!requiredForUsageURL" == '') || $requiredForUsageName == 'XWiki Standard')
-          which a standard installation of XWiki provides##
-        #elseif ("$!requiredForUsageName" != '')
-          #set ($escapedUsageName = $services.rendering.escape($requiredForUsageName, 'xwiki/2.1'))
-          which requires #renderMaybeLink($requiredForUsagePage, $requiredForUsagePageAnchor, $requiredForUsageURL, $escapedUsageName)##
-        #else
-          #set ($requiredForUsageId = $macroObj.getValue('requiredForUsageId'))
-          #set ($requiredForUsageContent = 'this')
-          #if ("$!requiredForUsageId" != '')
-            #set ($requiredForUsageContent = 'the {{code language="none" source="script:requiredForUsageId"/}} package')
-          #end
-          #set ($requiredForUsagePageAnchor = $macroObj.getValue('requiredForUsagePageAnchor'))
-          which requires #renderMaybeLink($requiredForUsagePage, $requiredForUsagePageAnchor, $requiredForUsageURL, 'package {{code language="none" source="script:requiredForUsageId"/}}')##
-        #end
-      #end.
-      #set ($requiredForImport = $macroObj.getValue('requiredForImport'))
-      #set ($requiredForImportPage = $macroObj.getValue('requiredForImportPage'))
-      #set ($requiredForImportPageAnchor = $macroObj.getValue('requiredForImportPageAnchor'))
-      #set ($requiredForImportId = $macroObj.getValue('requiredForImportId'))
-      #if ("$!requiredForImportId" == '')
-          #if ("$!requiredForImport" != '')
-
-            Importing this macro requires [[$services.rendering.escape($doc.getValue('requiredForImport'), 'xwiki/2.1')]].
-          #end
-      #elseif ($requiredForImportId != 'org.xwiki.contrib.confluence:confluence-xml' &amp;&amp; $requiredForImportId != 'com.xwiki.confluence:confluence-migration-package-ui')
-
-          Importing this macro requires #renderMaybeLink($requiredForImportPage, $requiredForImportPageAnchor, $requiredForImport, 'package {{code language="none" source="script:requiredForImportId"/}}').
+        uses #renderXWikiMacroList().
       #end
-      #set ($equivXWikiFeatureURL = $macroObj.getValue('equivXWikiFeatureURL'))
-      #set ($equivXWikiFeaturePageAnchor = $macroObj.getValue('equivXWikiFeaturePageAnchor'))
-      #set ($equivXWikiFeaturePage = $macroObj.getValue('equivXWikiFeaturePage'))
+      #set ($requiredForImportURLs = $macroObj.getValue('requiredForImport'))
+      #set ($requiredForImportNames = $macroObj.getValue('requiredForImportName'))
+      #set ($requiredForImportPages = $macroObj.getValue('requiredForImportPage'))
+      #set ($requiredForImportPageAnchors = $macroObj.getValue('requiredForImportPageAnchor'))
+      #set ($requiredForImportIds = $macroObj.getValue('requiredForImportId'))
+      #set ($requiredForImportMaxIndex = $mathtool.max($requiredForImportURLs.size(), $requiredForImportPages.size(), $requiredForImportPageAnchors.size(), $requiredForImportIds.size()) - 1)
+      #if ($requiredForImportMaxIndex &gt;= 0)
+        #foreach ($index in [0..$requiredForImportMaxIndex])
+          #if ($foreach.first)
+
+            Importing this macro requires ##
+          #end##
+          #maybeCommaOrAnd##
+          #readRequiredForImportVariables##
+          #if ("$!requiredForImportId" == '')
+            #set ($requiredForImportId = "$!requiredForImportPage$!requiredForImport")
+          #end
+          #if ("$!requiredForImportName" == "")
+            #set ($requiredForImportName = "package #renderAsCode($requiredForImportId)")
+          #else
+            #set ($requiredForImportName = $services.rendering.escape($requiredForImportName, 'xwiki/2.1'))
+          #end
+          #renderMaybeLink($requiredForImportPage, $requiredForImportPageAnchor, $requiredForImportURL, $requiredForImportName)
+          #if ($foreach.last).
+          #end
+        #end
+      #end
+      #if ($handling != 'drop')
+        #set ($requiredForUsageURLs = $macroObj.getValue('requiredForUsage'))
+        #set ($requiredForUsageNames = $macroObj.getValue('requiredForUsageName'))
+        #set ($requiredForUsagePages = $macroObj.getValue('requiredForUsagePage'))
+        #set ($requiredForUsagePageAnchors = $macroObj.getValue('requiredForUsagePageAnchor'))
+        #set ($requiredForUsageIds = $macroObj.getValue('requiredForUsageId'))
+        #set ($requiredForUsageMaxIndex = $mathtool.max($requiredForUsageURLs.size(), $requiredForUsagePages.size(), $requiredForUsagePageAnchors.size(), $requiredForUsageIds.size()) - 1)
+        #if ($requiredForUsageMaxIndex &gt;= 0)
+          #foreach ($index in [0..$requiredForUsageMaxIndex])
+            #if ($foreach.first)
+
+              The target macro requires ##
+            #end##
+            #maybeCommaOrAnd##
+            #readRequiredForUsageVariables##
+            #if ("$!requiredForUsageId" == '')
+              #set ($requiredForUsageId = "$!requiredForUsagePage$!requiredForUsage")
+            #end
+            #if ("$!requiredForUsageName" == "")
+              #set ($requiredForUsageName = "package #renderAsCode($requiredForUsageId)")
+            #else
+              #set ($requiredForUsageName = $services.rendering.escape($requiredForUsageName, 'xwiki/2.1'))
+            #end
+            #renderMaybeLink($requiredForUsagePage, $requiredForUsagePageAnchor, $requiredForUsageURL, $requiredForUsageName)
+            #if ($foreach.last).
+            #end
+          #end
+        #end
+      #end
+      #set ($equivXWikiFeatureURLs = $macroObj.getValue('equivXWikiFeatureURL'))
+      #set ($equivXWikiFeatureNames = $macroObj.getValue('equivXWikiFeatureName'))
+      #set ($equivXWikiFeaturePages = $macroObj.getValue('equivXWikiFeaturePage'))
+      #set ($equivXWikiFeaturePageAnchors = $macroObj.getValue('equivXWikiFeaturePageAnchor'))
+      #set ($equivXWikiFeatureIds = $macroObj.getValue('equivXWikiFeatureId'))
       #set ($correspondingXWikiFeature = $macroObj.getValue('correspondingXWikiFeature'))
-      #if ("$!equivXWikiFeatureURL" != '' || "$!correspondingXWikiFeature" != '' || "$!equivXWikiFeaturePage" != '' || ("$handling" != 'bridge' &amp;&amp; ("$!xwikiPage" != '' || "$!xwikiURL" != '')))
+      #if ("$!equivXWikiFeatureURLs" != '' || "$!correspondingXWikiFeature" != '' || "$!equivXWikiFeaturePages" != '' || ("$handling" != 'bridge' &amp;&amp; ("$!xwikiPages" != '' || "$!xwikiURLs" != '')))
 
         == What to use in XWiki ==
 
@@ -247,30 +384,37 @@
         $escapetool.xml($xwiki.getClass($className).get('correspondingXWikiFeature').hint)
         &lt;/span&gt;&lt;/div&gt;
         {{/html}}
+        #if ($doc.getValue('correspondingXWikiFeature').trim() != "")
 
         $doc.display('correspondingXWikiFeature')
-
+        #end
         ## Logic
         ## if it's a migration of type bridge -&gt; take equivXWikiFeature if set, otherwise nothing.
         ## for others type: take equivXWikiFeature if set, otherwise use xwikiPage
-        #if ("$!equivXWikiFeaturePage" != '')
-          #if ("$!equivXWikiFeaturePageAnchor" == '')
-            See [[$services.rendering.escape($equivXWikiFeaturePage, 'xwiki/2.1')]].
-          #else
-            See [[$services.rendering.escape($equivXWikiFeaturePage, 'xwiki/2.1')||anchor="$services.rendering.escape($equivXWikiFeaturePageAnchor, 'xwiki/2.1')"]].
-          #end
-        #elseif ("$!equivXWikiFeatureURL" != '' &amp;&amp; $equivXWikiFeatureURL != '?' &amp;&amp; $equivXWikiFeatureURL != '-')
-          See $doc.display('equivXWikiFeatureURL').
-        #elseif ($handling != 'bridge')
-          #if ("$!xwikiPage" != '')
-            #if ("$!xwikiPageAnchor" == '')
-              See [[$services.rendering.escape($xwikiPage, 'xwiki/2.1')]].
-            #else
-              See [[$services.rendering.escape($xwikiPage, 'xwiki/2.1')||anchor="$services.rendering.escape($xwikiPageAnchor, 'xwiki/2.1')"]].
+        #set ($equivXWikiFeatureMaxIndex = $mathtool.max($equivXWikiFeatureURLs.size(), $equivXWikiFeaturePages.size(), $equivXWikiFeaturePageAnchors.size(), $equivXWikiFeatureIds.size()) - 1)
+        #if ($equivXWikiFeatureMaxIndex &gt;= 0)
+          #foreach ($index in [0..$equivXWikiFeatureMaxIndex])
+            #if ($foreach.first)
+
+              See ##
+            #end##
+            #maybeCommaOrAnd##
+            #readEquivXWikiFeatureVariables##
+            #if ("$!equivXWikiFeatureId" == '')
+              #set ($equivXWikiFeatureId = "$!equivXWikiFeaturePage$!equivXWikiFeature")
             #end
-          #elseif ("$!xwikiURL" != '' &amp;&amp; $xwikiURL != '?' &amp;&amp; $xwikiURL != '-')
-            See $doc.display('xwikiURL').
+            #if ("$!equivXWikiFeatureName" == "")
+              #set ($equivXWikiFeatureName = "package #renderAsCode($equivXWikiFeatureId)")
+            #else
+              #set ($equivXWikiFeatureName = $services.rendering.escape($equivXWikiFeatureName, 'xwiki/2.1'))
+            #end
+            #renderMaybeLink($equivXWikiFeaturePage, $equivXWikiFeaturePageAnchor, $equivXWikiFeatureURL, $equivXWikiFeatureName)
+            #if ($foreach.last).
+            #end
           #end
+        #elseif ($handling != 'bridge')
+
+          See #renderXWikiMacroList().
         #end
       #end
       #set ($handlingDetails = $macroObj.getValue('handlingDetails').trim())

--- a/documentation-xwikiorg/documentation-xwikiorg-ui/src/main/resources/DocApp/Code/Confluence/ConfluenceMacroDocumentationTemplate.xml
+++ b/documentation-xwikiorg/documentation-xwikiorg-ui/src/main/resources/DocApp/Code/Confluence/ConfluenceMacroDocumentationTemplate.xml
@@ -56,7 +56,7 @@
         <disabled>0</disabled>
         <hint>Additional information</hint>
         <name>additionalInfo</name>
-        <number>25</number>
+        <number>28</number>
         <prettyName>Additional information</prettyName>
         <script/>
         <unmodifiable>0</unmodifiable>
@@ -97,11 +97,11 @@
         <customDisplay/>
         <disabled>0</disabled>
         <editor>---</editor>
-        <hint>How this macro would be implemented in XWiki and comparison with the corresponding feature</hint>
+        <hint>How this macro would be implemented in XWiki and comparison with the alternative feature</hint>
         <name>correspondingXWikiFeature</name>
-        <number>23</number>
+        <number>26</number>
         <picker>0</picker>
-        <prettyName>Corresponding feature in XWiki</prettyName>
+        <prettyName>Alternative XWiki feature description</prettyName>
         <restricted>0</restricted>
         <rows>5</rows>
         <size>40</size>
@@ -110,6 +110,56 @@
         <validationRegExp/>
         <classType>com.xpn.xwiki.objects.classes.TextAreaClass</classType>
       </correspondingXWikiFeature>
+      <equivXWikiFeatureId>
+        <cache>0</cache>
+        <customDisplay/>
+        <defaultValue/>
+        <disabled>0</disabled>
+        <displayType>input</displayType>
+        <freeText>allowed</freeText>
+        <hint>The extension id of a feature that should be used in XWiki for this feature regardless of the import. This should be only set if the value differs from "Import target XWiki ID" or for bridges to specify what the bridge uses and what to use in XWiki natively. You can give several comma-separated IDs.</hint>
+        <largeStorage>0</largeStorage>
+        <multiSelect>1</multiSelect>
+        <name>equivXWikiFeatureId</name>
+        <number>21</number>
+        <picker>1</picker>
+        <prettyName>Alternative XWiki feature extension ID</prettyName>
+        <relationalStorage>0</relationalStorage>
+        <separator>, </separator>
+        <separators>, |</separators>
+        <size>1</size>
+        <sort/>
+        <unmodifiable>0</unmodifiable>
+        <validationMessage/>
+        <validationRegExp/>
+        <values/>
+        <classType>com.xpn.xwiki.objects.classes.StaticListClass</classType>
+      </equivXWikiFeatureId>
+      <equivXWikiFeatureName>
+        <cache>0</cache>
+        <customDisplay/>
+        <defaultValue/>
+        <disabled>0</disabled>
+        <displayType>input</displayType>
+        <freeText>allowed</freeText>
+        <hint>The name of a feature that should be used in XWiki for this feature regardless of the import. This should be only set if the value differs from "Import target XWiki name" or for bridges to specify what the bridge uses and what to use in XWiki natively. You can give several comma-separated names.</hint>
+        <largeStorage>0</largeStorage>
+        <multiSelect>1</multiSelect>
+        <name>equivXWikiFeatureName</name>
+        <number>22</number>
+        <picker>0</picker>
+        <prettyName>Alternative XWiki feature name</prettyName>
+        <relationalStorage>0</relationalStorage>
+        <separator>, </separator>
+        <separators>, |</separators>
+        <size>1</size>
+        <sort/>
+        <unmodifiable>0</unmodifiable>
+        <validationMessage/>
+        <validationRegExp/>
+        <values/>
+        <classType>com.xpn.xwiki.objects.classes.StaticListClass</classType>
+      </equivXWikiFeatureName>
       <equivXWikiFeaturePage>
         <cache>0</cache>
         <classname/>
@@ -118,16 +168,16 @@
         <disabled>0</disabled>
         <displayType>input</displayType>
         <freeText/>
-        <hint>The documentation of a feature that should be used in XWiki for this feature regardless of the import</hint>
+        <hint>The documentation of a feature that should be used in XWiki for this feature regardless of the import. This should be only set if the value differs from "Import target XWiki URL" or for bridges to specify what the bridge uses and what to use in XWiki natively.</hint>
         <idField/>
         <largeStorage>0</largeStorage>
-        <multiSelect>0</multiSelect>
+        <multiSelect>1</multiSelect>
         <name>equivXWikiFeaturePage</name>
-        <number>20</number>
+        <number>23</number>
         <picker>1</picker>
-        <prettyName>Equivalent XWiki feature documentation page</prettyName>
+        <prettyName>Alternative XWiki feature documentation page</prettyName>
         <relationalStorage>0</relationalStorage>
-        <separator> </separator>
+        <separator>, </separator>
         <separators/>
         <size>1</size>
         <sort/>
@@ -139,49 +189,71 @@
         <classType>com.xpn.xwiki.objects.classes.PageClass</classType>
       </equivXWikiFeaturePage>
       <equivXWikiFeaturePageAnchor>
+        <cache>0</cache>
         <customDisplay/>
+        <defaultValue/>
         <disabled>0</disabled>
-        <hint>The anchor in the documentation of a feature that should be used in XWiki for this feature regardless of the import</hint>
+        <displayType>input</displayType>
+        <freeText>allowed</freeText>
+        <hint>The anchor in the documentation of a feature that should be used in XWiki for this feature regardless of the import.</hint>
+        <largeStorage>0</largeStorage>
+        <multiSelect>1</multiSelect>
         <name>equivXWikiFeaturePageAnchor</name>
-        <number>21</number>
-        <picker>1</picker>
-        <prettyName>Equivalent XWiki feature documentation page anchor</prettyName>
-        <size>30</size>
+        <number>24</number>
+        <picker>0</picker>
+        <prettyName>Alternative XWiki feature documentation page anchor</prettyName>
+        <relationalStorage>0</relationalStorage>
+        <separator>, </separator>
+        <separators>, |</separators>
+        <size>1</size>
+        <sort/>
         <unmodifiable>0</unmodifiable>
         <validationMessage/>
         <validationRegExp/>
-        <classType>com.xpn.xwiki.objects.classes.StringClass</classType>
+        <values/>
+        <classType>com.xpn.xwiki.objects.classes.StaticListClass</classType>
       </equivXWikiFeaturePageAnchor>
       <equivXWikiFeatureURL>
+        <cache>0</cache>
         <customDisplay/>
+        <defaultValue>29</defaultValue>
         <disabled>0</disabled>
-        <hint>The URL to the feature that should be used in XWiki for this feature regardless of the import</hint>
+        <displayType>input</displayType>
+        <freeText>allowed</freeText>
+        <hint>The URL to the feature that should be used in XWiki for this feature regardless of the import. This should be only set if the value differs from "Import target XWiki URL" or for bridges to specify what the bridge uses and what to use in XWiki natively. You can give several comma-separated URLs.</hint>
+        <largeStorage>0</largeStorage>
+        <multiSelect>1</multiSelect>
         <name>equivXWikiFeatureURL</name>
-        <number>22</number>
+        <number>25</number>
         <picker>0</picker>
-        <prettyName>Equivalent XWiki feature documentation URL</prettyName>
-        <size>30</size>
+        <prettyName>Alternative XWiki feature documentation URL</prettyName>
+        <relationalStorage>0</relationalStorage>
+        <separator>, </separator>
+        <separators>, |</separators>
+        <size>1</size>
+        <sort/>
         <unmodifiable>0</unmodifiable>
         <validationMessage/>
         <validationRegExp/>
-        <classType>com.xpn.xwiki.objects.classes.StringClass</classType>
+        <values/>
+        <classType>com.xpn.xwiki.objects.classes.StaticListClass</classType>
       </equivXWikiFeatureURL>
       <functionalEquivalenceQualifier>
         <cache>0</cache>
         <customDisplay/>
         <defaultValue/>
         <disabled>0</disabled>
-        <displayType>select</displayType>
-        <freeText/>
-        <hint/>
+        <displayType>input</displayType>
+        <freeText>allowed</freeText>
+        <hint>How well the alternative feature in XWiki is equivalent to the Confluence feature. If the alternative XWiki feature brings the same features with no important limitations, we consider  full equivalence. If equivalent features lack or have limitations, depending on the situation, we consider partial equivalence.</hint>
         <largeStorage>0</largeStorage>
         <multiSelect>0</multiSelect>
         <name>functionalEquivalenceQualifier</name>
-        <number>6</number>
+        <number>27</number>
         <picker>1</picker>
         <prettyName>Functional Equivalence Qualifier</prettyName>
         <relationalStorage>0</relationalStorage>
-        <separator> </separator>
+        <separator>, </separator>
         <separators>|, </separators>
         <size>1</size>
         <sort/>
@@ -198,7 +270,7 @@
         <disabled>0</disabled>
         <displayType>select</displayType>
         <freeText/>
-        <hint/>
+        <hint>There are different ways to import and handle Confluence macros in XWiki. This hints at how the macro looks like after a migration to XWiki.</hint>
         <largeStorage>0</largeStorage>
         <multiSelect>0</multiSelect>
         <name>handling</name>
@@ -213,7 +285,7 @@
         <unmodifiable>0</unmodifiable>
         <validationMessage/>
         <validationRegExp/>
-        <values>conversionToMacro|conversionToSyntax|bridge|placeholder|shallow|drop</values>
+        <values>conversionToMacro=Conversion to macro|conversionToSyntax=Conversion to syntax|bridge=Bridge|placeholder=Placeholder|shallow=Shallow|drop=Drop</values>
         <classType>com.xpn.xwiki.objects.classes.StaticListClass</classType>
       </handling>
       <handlingDetails>
@@ -223,7 +295,7 @@
         <editor>---</editor>
         <hint>Details on how (well) this Confluence macro is imported</hint>
         <name>handlingDetails</name>
-        <number>24</number>
+        <number>29</number>
         <picker>0</picker>
         <prettyName>Import handling details</prettyName>
         <restricted>0</restricted>
@@ -239,13 +311,13 @@
         <customDisplay/>
         <defaultValue/>
         <disabled>0</disabled>
-        <displayType>select</displayType>
+        <displayType>input</displayType>
         <freeText>allowed</freeText>
-        <hint>How well the macro is imported in XWiki</hint>
+        <hint>How well the Confluence macro is handled in XWiki. If all Confluence macro parameters are mapped to supported XWiki macro parameters, we consider this fully supported. If some parameters are not supported in XWiki, depending on the situation, we consider this partial.</hint>
         <largeStorage>0</largeStorage>
         <multiSelect>0</multiSelect>
         <name>importSupportQualifier</name>
-        <number>5</number>
+        <number>8</number>
         <picker>1</picker>
         <prettyName>Import Quality Qualifier</prettyName>
         <relationalStorage>0</relationalStorage>
@@ -260,9 +332,9 @@
         <classType>com.xpn.xwiki.objects.classes.StaticListClass</classType>
       </importSupportQualifier>
       <prettyName>
-        <customDisplay>{{include reference="AppWithinMinutes.Title"/}}</customDisplay>
+        <customDisplay>{{include reference="DocApp.Code.Confluence.ConfluenceTitleDisplayer"/}}</customDisplay>
         <disabled>0</disabled>
-        <hint>The user-friendly macro name as it is presented in confluence (different from the confluence ID which is the technical name)</hint>
+        <hint>The user-friendly macro name as it is presented in Confluence (different from the confluence ID which is the technical name)</hint>
         <name>prettyName</name>
         <number>1</number>
         <prettyName>User-friendly macro name</prettyName>
@@ -273,33 +345,80 @@
         <classType>com.xpn.xwiki.objects.classes.ComputedFieldClass</classType>
       </prettyName>
       <requiredForImport>
+        <cache>0</cache>
         <customDisplay/>
+        <defaultValue/>
         <disabled>0</disabled>
-        <hint>URL to an extension required for importing this macro</hint>
+        <displayType>input</displayType>
+        <freeText/>
+        <hint>URL to an extension required for importing this macro. You can give several comma-separated URLs.</hint>
+        <largeStorage>0</largeStorage>
+        <multiSelect>1</multiSelect>
         <name>requiredForImport</name>
-        <number>14</number>
+        <number>15</number>
         <picker>0</picker>
-        <prettyName>Required for import URL</prettyName>
-        <size>30</size>
+        <prettyName>Required for import documentation URL</prettyName>
+        <relationalStorage>0</relationalStorage>
+        <separator>, </separator>
+        <separators>, |</separators>
+        <size>1</size>
+        <sort/>
         <unmodifiable>0</unmodifiable>
         <validationMessage/>
         <validationRegExp/>
-        <classType>com.xpn.xwiki.objects.classes.StringClass</classType>
+        <values/>
+        <classType>com.xpn.xwiki.objects.classes.StaticListClass</classType>
       </requiredForImport>
       <requiredForImportId>
+        <cache>0</cache>
         <customDisplay/>
+        <defaultValue/>
         <disabled>0</disabled>
-        <hint>ID of an extension required for importing this macro</hint>
+        <displayType>input</displayType>
+        <freeText/>
+        <hint>ID of an extension required for importing this macro. You can give several comma-separated IDs.</hint>
+        <largeStorage>0</largeStorage>
+        <multiSelect>1</multiSelect>
         <name>requiredForImportId</name>
-        <number>13</number>
+        <number>11</number>
         <picker>0</picker>
         <prettyName>Required for import extension ID</prettyName>
-        <size>30</size>
+        <relationalStorage>0</relationalStorage>
+        <separator>, </separator>
+        <separators>, |</separators>
+        <size>1</size>
+        <sort/>
         <unmodifiable>0</unmodifiable>
         <validationMessage/>
         <validationRegExp/>
-        <classType>com.xpn.xwiki.objects.classes.StringClass</classType>
+        <values/>
+        <classType>com.xpn.xwiki.objects.classes.StaticListClass</classType>
       </requiredForImportId>
+      <requiredForImportName>
+        <cache>0</cache>
+        <customDisplay/>
+        <defaultValue/>
+        <disabled>0</disabled>
+        <displayType>input</displayType>
+        <freeText>allowed</freeText>
+        <hint>User-friendly name of the extension required for importing the macro. You can give several comma-separated names.</hint>
+        <largeStorage>0</largeStorage>
+        <multiSelect>1</multiSelect>
+        <name>requiredForImportName</name>
+        <number>12</number>
+        <picker>1</picker>
+        <prettyName> Required for import extension name</prettyName>
+        <relationalStorage>0</relationalStorage>
+        <separator>, </separator>
+        <separators>, |</separators>
+        <size>1</size>
+        <sort/>
+        <unmodifiable>0</unmodifiable>
+        <validationMessage/>
+        <validationRegExp/>
+        <values/>
+        <classType>com.xpn.xwiki.objects.classes.StaticListClass</classType>
+      </requiredForImportName>
       <requiredForImportPage>
         <cache>0</cache>
         <classname/>
@@ -307,17 +426,17 @@
         <defaultValue/>
         <disabled>0</disabled>
         <displayType>input</displayType>
-        <freeText/>
-        <hint>Page of an extension required for importing this macro</hint>
+        <freeText>allowed</freeText>
+        <hint>Page of an extension required for importing this macro.</hint>
         <idField/>
         <largeStorage>0</largeStorage>
-        <multiSelect>0</multiSelect>
+        <multiSelect>1</multiSelect>
         <name>requiredForImportPage</name>
-        <number>11</number>
+        <number>13</number>
         <picker>1</picker>
         <prettyName>Required for import documentation page</prettyName>
         <relationalStorage>0</relationalStorage>
-        <separator> </separator>
+        <separator>, </separator>
         <separators/>
         <size>1</size>
         <sort/>
@@ -329,60 +448,104 @@
         <classType>com.xpn.xwiki.objects.classes.PageClass</classType>
       </requiredForImportPage>
       <requiredForImportPageAnchor>
+        <cache>0</cache>
         <customDisplay/>
+        <defaultValue/>
         <disabled>0</disabled>
-        <hint>Anchor in the page of an extension required for importing this macro</hint>
+        <displayType>input</displayType>
+        <freeText/>
+        <hint>Anchor in the page of an extension required for importing this macro.</hint>
+        <largeStorage>0</largeStorage>
+        <multiSelect>1</multiSelect>
         <name>requiredForImportPageAnchor</name>
-        <number>12</number>
-        <picker>1</picker>
+        <number>14</number>
+        <picker>0</picker>
         <prettyName>Required for import documentation page anchor</prettyName>
-        <size>30</size>
+        <relationalStorage>0</relationalStorage>
+        <separator>, </separator>
+        <separators>, |</separators>
+        <size>1</size>
+        <sort/>
         <unmodifiable>0</unmodifiable>
         <validationMessage/>
         <validationRegExp/>
-        <classType>com.xpn.xwiki.objects.classes.StringClass</classType>
+        <values/>
+        <classType>com.xpn.xwiki.objects.classes.StaticListClass</classType>
       </requiredForImportPageAnchor>
       <requiredForUsage>
+        <cache>0</cache>
         <customDisplay/>
+        <defaultValue/>
         <disabled>0</disabled>
-        <hint>URL to the documentation of a extension required for using the imported macro</hint>
+        <displayType>input</displayType>
+        <freeText>allowed</freeText>
+        <hint>URL to the documentation of a extension required for using the imported macro. You can give several comma-separated URLs.</hint>
+        <largeStorage>0</largeStorage>
+        <multiSelect>1</multiSelect>
         <name>requiredForUsage</name>
-        <number>19</number>
+        <number>20</number>
         <picker>0</picker>
-        <prettyName>Required for usage URL</prettyName>
-        <size>30</size>
+        <prettyName>Required for usage documentation URL</prettyName>
+        <relationalStorage>0</relationalStorage>
+        <separator>, </separator>
+        <separators>, |</separators>
+        <size>1</size>
+        <sort/>
         <unmodifiable>0</unmodifiable>
         <validationMessage/>
         <validationRegExp/>
-        <classType>com.xpn.xwiki.objects.classes.StringClass</classType>
+        <values/>
+        <classType>com.xpn.xwiki.objects.classes.StaticListClass</classType>
       </requiredForUsage>
       <requiredForUsageId>
+        <cache>0</cache>
         <customDisplay/>
+        <defaultValue>29</defaultValue>
         <disabled>0</disabled>
-        <hint>ID of an extension required for using this macro</hint>
+        <displayType>input</displayType>
+        <freeText/>
+        <hint>ID of an extension required for using this macro. You can give several comma-separated IDs.</hint>
+        <largeStorage>0</largeStorage>
+        <multiSelect>1</multiSelect>
         <name>requiredForUsageId</name>
-        <number>15</number>
+        <number>16</number>
         <picker>0</picker>
         <prettyName>Required for usage extension ID</prettyName>
-        <size>30</size>
+        <relationalStorage>0</relationalStorage>
+        <separator>, </separator>
+        <separators>, |</separators>
+        <size>1</size>
+        <sort/>
         <unmodifiable>0</unmodifiable>
         <validationMessage/>
         <validationRegExp/>
-        <classType>com.xpn.xwiki.objects.classes.StringClass</classType>
+        <values/>
+        <classType>com.xpn.xwiki.objects.classes.StaticListClass</classType>
       </requiredForUsageId>
       <requiredForUsageName>
+        <cache>0</cache>
         <customDisplay/>
+        <defaultValue/>
         <disabled>0</disabled>
-        <hint>Name of an extension required for using this macro</hint>
+        <displayType>input</displayType>
+        <freeText/>
+        <hint>Name of an extension required for using this macro. You can give several comma-separated names.</hint>
+        <largeStorage>0</largeStorage>
+        <multiSelect>1</multiSelect>
         <name>requiredForUsageName</name>
-        <number>16</number>
-        <picker>1</picker>
+        <number>17</number>
+        <picker>0</picker>
         <prettyName>Required for usage extension name</prettyName>
-        <size>30</size>
+        <relationalStorage>0</relationalStorage>
+        <separator>, </separator>
+        <separators>, |</separators>
+        <size>1</size>
+        <sort/>
         <unmodifiable>0</unmodifiable>
         <validationMessage/>
         <validationRegExp/>
-        <classType>com.xpn.xwiki.objects.classes.StringClass</classType>
+        <values/>
+        <classType>com.xpn.xwiki.objects.classes.StaticListClass</classType>
       </requiredForUsageName>
       <requiredForUsagePage>
         <cache>0</cache>
@@ -392,18 +555,18 @@
         <disabled>0</disabled>
         <displayType>input</displayType>
         <freeText/>
-        <hint>Documentation page of an extension required for using this macro</hint>
+        <hint>Documentation page of an extension required for using this macro.</hint>
         <idField/>
         <largeStorage>0</largeStorage>
-        <multiSelect>0</multiSelect>
+        <multiSelect>1</multiSelect>
         <name>requiredForUsagePage</name>
-        <number>17</number>
+        <number>18</number>
         <picker>1</picker>
         <prettyName>Required for usage documentation page</prettyName>
         <relationalStorage>0</relationalStorage>
-        <separator> </separator>
+        <separator>, </separator>
         <separators/>
-        <size>1</size>
+        <size>28</size>
         <sort/>
         <sql/>
         <unmodifiable>0</unmodifiable>
@@ -413,33 +576,80 @@
         <classType>com.xpn.xwiki.objects.classes.PageClass</classType>
       </requiredForUsagePage>
       <requiredForUsagePageAnchor>
+        <cache>0</cache>
         <customDisplay/>
+        <defaultValue/>
         <disabled>0</disabled>
-        <hint>Documentation page anchor of an extension required for using this macro</hint>
+        <displayType>input</displayType>
+        <freeText/>
+        <hint>Documentation page anchor of an extension required for using this macro.</hint>
+        <largeStorage>0</largeStorage>
+        <multiSelect>1</multiSelect>
         <name>requiredForUsagePageAnchor</name>
-        <number>18</number>
-        <picker>1</picker>
+        <number>19</number>
+        <picker>0</picker>
         <prettyName>Required for usage documentation page anchor</prettyName>
-        <size>30</size>
+        <relationalStorage>0</relationalStorage>
+        <separator>, </separator>
+        <separators>, |</separators>
+        <size>1</size>
+        <sort/>
         <unmodifiable>0</unmodifiable>
         <validationMessage/>
-        <validationRegExp/>
-        <classType>com.xpn.xwiki.objects.classes.StringClass</classType>
+        <validationRegExp>, </validationRegExp>
+        <values/>
+        <classType>com.xpn.xwiki.objects.classes.StaticListClass</classType>
       </requiredForUsagePageAnchor>
       <xwikiId>
+        <cache>0</cache>
         <customDisplay/>
+        <defaultValue/>
         <disabled>0</disabled>
-        <hint>The import target macro, if applicable</hint>
+        <displayType>input</displayType>
+        <freeText>allowed</freeText>
+        <hint>The import target macro, if applicable. You can give several comma-separated macros.</hint>
+        <largeStorage>0</largeStorage>
+        <multiSelect>1</multiSelect>
         <name>xwikiId</name>
-        <number>7</number>
+        <number>9</number>
         <picker>0</picker>
         <prettyName>Import target XWiki ID</prettyName>
-        <size>30</size>
+        <relationalStorage>0</relationalStorage>
+        <separator>, </separator>
+        <separators>, |</separators>
+        <size>1</size>
+        <sort/>
         <unmodifiable>0</unmodifiable>
         <validationMessage/>
         <validationRegExp/>
-        <classType>com.xpn.xwiki.objects.classes.StringClass</classType>
+        <values/>
+        <classType>com.xpn.xwiki.objects.classes.StaticListClass</classType>
       </xwikiId>
+      <xwikiName>
+        <cache>0</cache>
+        <customDisplay/>
+        <defaultValue/>
+        <disabled>0</disabled>
+        <displayType>input</displayType>
+        <freeText>allowed</freeText>
+        <hint>The (user-friendly) name of the import target, if applicable. You can give several comma-separated names.</hint>
+        <largeStorage>0</largeStorage>
+        <multiSelect>1</multiSelect>
+        <name>xwikiName</name>
+        <number>5</number>
+        <picker>1</picker>
+        <prettyName>Import target XWiki name</prettyName>
+        <relationalStorage>0</relationalStorage>
+        <separator>, </separator>
+        <separators>, |</separators>
+        <size>1</size>
+        <sort/>
+        <unmodifiable>0</unmodifiable>
+        <validationMessage/>
+        <validationRegExp/>
+        <values/>
+        <classType>com.xpn.xwiki.objects.classes.StaticListClass</classType>
+      </xwikiName>
       <xwikiPage>
         <cache>0</cache>
         <classname/>
@@ -447,17 +657,17 @@
         <defaultValue/>
         <disabled>0</disabled>
         <displayType>input</displayType>
-        <freeText/>
-        <hint>The import target macro documentation, if applicable</hint>
+        <freeText>allowed</freeText>
+        <hint>The import target macro documentation, if applicable.</hint>
         <idField/>
         <largeStorage>0</largeStorage>
-        <multiSelect>0</multiSelect>
+        <multiSelect>1</multiSelect>
         <name>xwikiPage</name>
-        <number>8</number>
+        <number>10</number>
         <picker>1</picker>
         <prettyName>Import target XWiki page</prettyName>
         <relationalStorage>0</relationalStorage>
-        <separator> </separator>
+        <separator>, </separator>
         <separators/>
         <size>1</size>
         <sort/>
@@ -469,32 +679,54 @@
         <classType>com.xpn.xwiki.objects.classes.PageClass</classType>
       </xwikiPage>
       <xwikiPageAnchor>
+        <cache>0</cache>
         <customDisplay/>
+        <defaultValue/>
         <disabled>0</disabled>
-        <hint>The anchor in the import target macro documentation, if applicable</hint>
+        <displayType>input</displayType>
+        <freeText>allowed</freeText>
+        <hint>The anchor in the import target macro documentation, if applicable.</hint>
+        <largeStorage>0</largeStorage>
+        <multiSelect>1</multiSelect>
         <name>xwikiPageAnchor</name>
-        <number>9</number>
-        <picker>1</picker>
+        <number>6</number>
+        <picker>0</picker>
         <prettyName>Import target XWiki page anchor</prettyName>
-        <size>30</size>
+        <relationalStorage>0</relationalStorage>
+        <separator>, </separator>
+        <separators>, |</separators>
+        <size>1</size>
+        <sort/>
         <unmodifiable>0</unmodifiable>
         <validationMessage/>
         <validationRegExp/>
-        <classType>com.xpn.xwiki.objects.classes.StringClass</classType>
+        <values/>
+        <classType>com.xpn.xwiki.objects.classes.StaticListClass</classType>
       </xwikiPageAnchor>
       <xwikiURL>
+        <cache>0</cache>
         <customDisplay/>
+        <defaultValue/>
         <disabled>0</disabled>
-        <hint>The import target macro documentation, if applicable</hint>
+        <displayType>input</displayType>
+        <freeText>allowed</freeText>
+        <hint>The import target macro documentation URL, if applicable. You can give several comma-separated URLs.</hint>
+        <largeStorage>0</largeStorage>
+        <multiSelect>1</multiSelect>
         <name>xwikiURL</name>
-        <number>10</number>
+        <number>7</number>
         <picker>0</picker>
         <prettyName>Import target XWiki URL</prettyName>
-        <size>30</size>
+        <relationalStorage>0</relationalStorage>
+        <separator>, </separator>
+        <separators>, |</separators>
+        <size>1</size>
+        <sort/>
         <unmodifiable>0</unmodifiable>
         <validationMessage/>
         <validationRegExp/>
-        <classType>com.xpn.xwiki.objects.classes.StringClass</classType>
+        <values/>
+        <classType>com.xpn.xwiki.objects.classes.StaticListClass</classType>
       </xwikiURL>
     </class>
     <property>
@@ -505,6 +737,12 @@
     </property>
     <property>
       <correspondingXWikiFeature/>
+    </property>
+    <property>
+      <equivXWikiFeatureId/>
+    </property>
+    <property>
+      <equivXWikiFeatureName/>
     </property>
     <property>
       <equivXWikiFeaturePage/>
@@ -534,6 +772,9 @@
       <requiredForImportId/>
     </property>
     <property>
+      <requiredForImportName/>
+    </property>
+    <property>
       <requiredForImportPage/>
     </property>
     <property>
@@ -556,6 +797,9 @@
     </property>
     <property>
       <xwikiId/>
+    </property>
+    <property>
+      <xwikiName/>
     </property>
     <property>
       <xwikiPage/>

--- a/documentation-xwikiorg/documentation-xwikiorg-ui/src/main/resources/DocApp/Code/Confluence/ConfluencePluginDocumentationTemplate.xml
+++ b/documentation-xwikiorg/documentation-xwikiorg-ui/src/main/resources/DocApp/Code/Confluence/ConfluencePluginDocumentationTemplate.xml
@@ -99,7 +99,7 @@
         <picker>1</picker>
         <prettyName>Plugin ID(s)</prettyName>
         <relationalStorage>1</relationalStorage>
-        <separator> ,</separator>
+        <separator>, </separator>
         <separators>,</separators>
         <size>1</size>
         <sort/>
@@ -141,7 +141,7 @@
         <picker>1</picker>
         <prettyName>Alternative plugin name</prettyName>
         <relationalStorage>1</relationalStorage>
-        <separator> ,</separator>
+        <separator>, </separator>
         <separators>,</separators>
         <size>1</size>
         <sort/>
@@ -153,7 +153,7 @@
         <classType>com.xpn.xwiki.objects.classes.DBListClass</classType>
       </pluginName>
       <prettyName>
-        <customDisplay>{{include reference="AppWithinMinutes.Title"/}}</customDisplay>
+        <customDisplay>{{include reference="DocApp.Code.Confluence.ConfluenceTitleDisplayer"/}}</customDisplay>
         <disabled>0</disabled>
         <hint>The plugin name</hint>
         <name>prettyName</name>
@@ -182,7 +182,7 @@
         <picker>1</picker>
         <prettyName>Publisher</prettyName>
         <relationalStorage>1</relationalStorage>
-        <separator> ,</separator>
+        <separator>, </separator>
         <separators>,</separators>
         <size>1</size>
         <sort/>

--- a/pom.xml
+++ b/pom.xml
@@ -78,4 +78,13 @@
       </plugins>
     </pluginManagement>
   </build>
+  <dependencyManagement>
+    <dependencies>
+      <dependency>
+        <groupId>org.bouncycastle</groupId>
+        <artifactId>bcprov-jdk18on</artifactId>
+        <version>1.80.2</version>
+      </dependency>
+    </dependencies>
+  </dependencyManagement>
 </project>


### PR DESCRIPTION
# OP URL

- https://op.xwiki.org/projects/documentation-application/work_packages/118
- https://op.xwiki.org/projects/documentation-application/work_packages/119
- https://op.xwiki.org/projects/documentation-application/work_packages/120
- https://op.xwiki.org/projects/documentation-application/work_packages/121

# Changes

## Description

- allow multiple choices for most fields designating XWiki features
- make sure to use the right separators Confluence macro documentation
- make sure all XWiki features have id, name, page, page anchor and url fields allowing multiple selections
- change "equivalent" to "alternative"

# Executed Tests

manual

# Expected merging strategy

* Prefers squash: Yes <!-- No — Explain why. -->
* Backport on branches: none